### PR TITLE
Redesign Tech Philosophers site with modular layout

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>About — The Tech Philosophers</title>
+    <meta name="description" content="Discover the journey of Raju Thoutu and the vision behind The Tech Philosophers." />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Poppins:wght@500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="icon" type="image/svg+xml" href="assets/images/favicon.svg" />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header class="site-header" id="top">
+      <div class="container header__inner">
+        <a class="brand" href="index.html" aria-label="The Tech Philosophers home">
+          <span class="brand__mark" aria-hidden="true">◎</span>
+          <span class="brand__text">
+            <span class="brand__title">The Tech Philosophers</span>
+            <span class="brand__tagline">Raju Thoutu</span>
+          </span>
+        </a>
+        <button class="nav-toggle" type="button" aria-controls="primary-nav" aria-expanded="false">
+          <span class="sr-only">Toggle navigation</span>
+          <span class="nav-toggle__line"></span>
+          <span class="nav-toggle__line"></span>
+          <span class="nav-toggle__line"></span>
+        </button>
+        <nav class="site-nav" aria-label="Primary">
+          <ul id="primary-nav" class="site-nav__list">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="about.html" aria-current="page">About</a></li>
+            <li><a href="insights.html">Insights</a></li>
+            <li><a href="projects.html">Projects</a></li>
+            <li><a href="podcasts.html">Podcasts &amp; Videos</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </nav>
+        <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Activate dark mode">
+          <span class="sr-only">Toggle theme</span>
+          <span class="theme-toggle__icon" aria-hidden="true"></span>
+        </button>
+      </div>
+    </header>
+
+    <main id="main-content" class="page">
+      <section class="page-hero">
+        <div class="container narrow">
+          <p class="eyebrow">About</p>
+          <h1>Technologist, educator, podcaster — bridging ancient wisdom with tomorrow’s systems.</h1>
+          <p class="lead">
+            Raju Thoutu is the mind behind The Tech Philosophers, a platform built to translate emerging technology and Bharatiya
+            philosophy into everyday decisions for leaders, parents, and curious learners.
+          </p>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="container split">
+          <div>
+            <h2>Who I am</h2>
+            <p>
+              I am a Lead System Architect and AI practitioner guiding organizations as they modernize responsibly. From low-code
+              automations to enterprise data strategies, my focus remains consistent: design technology that respects people.
+            </p>
+            <p>
+              Outside boardrooms, I teach, facilitate workshops, and host conversations that simplify dense topics into actionable
+              clarity.
+            </p>
+          </div>
+          <div>
+            <h2>My background</h2>
+            <ul class="timeline">
+              <li><strong>Hyderabad roots:</strong> Grew up immersed in storytelling, mathematics, and classical philosophy.</li>
+              <li><strong>Journey to the US:</strong> Built cross-continental expertise in enterprise architecture and transformation.</li>
+              <li><strong>Lead System Architect:</strong> Helping Fortune 500 teams align strategy, process, and data with purposeful design.</li>
+              <li><strong>AI practitioner:</strong> Prototyping copilots, knowledge engines, and education models grounded in ethics.</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section--surface">
+        <div class="container narrow">
+          <h2>Why The Tech Philosophers exists</h2>
+          <p>
+            Technology shapes behavior, yet wisdom gives it meaning. This platform combines research, storytelling, and systems
+            thinking to help people make choices that honor both progress and humanity. Everything is written in simple English,
+            intentionally calm, and free from buzzwords.
+          </p>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="container split">
+          <div>
+            <h2>Long-term vision</h2>
+            <ul class="vision-list">
+              <li>AI education that builds discernment, not dependence.</li>
+              <li>Holistic schooling models inspired by Anushtan’s research.</li>
+              <li>Resources for parents guiding digital natives with empathy.</li>
+              <li>Spaces for technologists to explore philosophy without judgment.</li>
+            </ul>
+          </div>
+          <div>
+            <h2>How we work</h2>
+            <p>
+              The Tech Philosophers brand is modular and extendable. Every page, playlist, and research note nests into a broader
+              knowledge system — ready to scale to hundreds of insights without losing clarity or warmth.
+            </p>
+            <a class="btn btn--primary" href="insights.html">Explore the insights system</a>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container footer__grid">
+        <div>
+          <a class="brand brand--small" href="index.html">
+            <span class="brand__mark" aria-hidden="true">◎</span>
+            <span class="brand__title">The Tech Philosophers</span>
+          </a>
+          <p class="footer__tagline">Calm intelligence for a meaningful technological future.</p>
+        </div>
+        <nav aria-label="Footer">
+          <ul class="footer__nav">
+            <li><a href="about.html" aria-current="page">About</a></li>
+            <li><a href="insights.html">Insights</a></li>
+            <li><a href="projects.html">Projects</a></li>
+            <li><a href="podcasts.html">Podcasts</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </nav>
+      </div>
+      <p class="footer__legal">© <span data-year></span> Raju Thoutu · Crafted with clarity and conscience.</p>
+    </footer>
+
+    <script src="assets/js/main.js" defer></script>
+  </body>
+</html>

--- a/article-template.html
+++ b/article-template.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Insight Template — The Tech Philosophers</title>
+    <meta name="description" content="Template for The Tech Philosophers articles with modular table of contents and metadata." />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Poppins:wght@500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="icon" type="image/svg+xml" href="assets/images/favicon.svg" />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header class="site-header" id="top">
+      <div class="container header__inner">
+        <a class="brand" href="index.html" aria-label="The Tech Philosophers home">
+          <span class="brand__mark" aria-hidden="true">◎</span>
+          <span class="brand__text">
+            <span class="brand__title">The Tech Philosophers</span>
+            <span class="brand__tagline">Raju Thoutu</span>
+          </span>
+        </a>
+        <button class="nav-toggle" type="button" aria-controls="primary-nav" aria-expanded="false">
+          <span class="sr-only">Toggle navigation</span>
+          <span class="nav-toggle__line"></span>
+          <span class="nav-toggle__line"></span>
+          <span class="nav-toggle__line"></span>
+        </button>
+        <nav class="site-nav" aria-label="Primary">
+          <ul id="primary-nav" class="site-nav__list">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="about.html">About</a></li>
+            <li><a href="insights.html">Insights</a></li>
+            <li><a href="projects.html">Projects</a></li>
+            <li><a href="podcasts.html">Podcasts &amp; Videos</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </nav>
+        <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Activate dark mode">
+          <span class="sr-only">Toggle theme</span>
+          <span class="theme-toggle__icon" aria-hidden="true"></span>
+        </button>
+      </div>
+    </header>
+
+    <main id="main-content" class="page article">
+      <article class="article__layout">
+        <header class="article__header">
+          <p class="article__category">Technology &amp; AI Insights</p>
+          <h1>Sample article title placed here for layout preview</h1>
+          <p class="article__meta">Published June 12, 2025 · Tags: <a href="#">LLM</a>, <a href="#">Enterprise Architecture</a></p>
+        </header>
+
+        <aside class="article__toc" aria-label="Table of contents">
+          <p class="article__toc-title">Table of contents</p>
+          <ol>
+            <li><a href="#section-1">Context &amp; question</a></li>
+            <li><a href="#section-2">Framework</a></li>
+            <li><a href="#section-3">Case application</a></li>
+            <li><a href="#section-4">Reflection prompts</a></li>
+          </ol>
+        </aside>
+
+        <div class="article__body">
+          <section id="section-1">
+            <h2>Context &amp; question</h2>
+            <p>
+              Use this space to outline why the topic matters. Introduce the philosophical angle, the technological scenario, and
+              the audience pain point in simple English.
+            </p>
+          </section>
+          <section id="section-2">
+            <h2>Framework</h2>
+            <p>
+              Present the guiding model or mental map. Visuals such as neural networks or Sri Yantra line art can be embedded here
+              as SVGs or background graphics.
+            </p>
+            <ul>
+              <li>Principle 1 — Technology with conscience.</li>
+              <li>Principle 2 — Education that nurtures curiosity.</li>
+              <li>Principle 3 — Society with compassionate leadership.</li>
+            </ul>
+          </section>
+          <section id="section-3">
+            <h2>Case application</h2>
+            <p>
+              Detail how the framework applies to a real project. Reference AI tools, mythology analogies, or education research as
+              needed.
+            </p>
+            <blockquote>
+              “Every system we design should make it easier for people to choose wisdom over speed.”
+            </blockquote>
+          </section>
+          <section id="section-4">
+            <h2>Reflection prompts</h2>
+            <p>Close with actions, journaling questions, or discussion prompts.</p>
+            <ol>
+              <li>Where does your team need more clarity?</li>
+              <li>How will you measure transformation beyond metrics?</li>
+              <li>What wisdom tradition can help answer your next decision?</li>
+            </ol>
+          </section>
+        </div>
+      </article>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container footer__grid">
+        <div>
+          <a class="brand brand--small" href="index.html">
+            <span class="brand__mark" aria-hidden="true">◎</span>
+            <span class="brand__title">The Tech Philosophers</span>
+          </a>
+          <p class="footer__tagline">Calm intelligence for a meaningful technological future.</p>
+        </div>
+        <nav aria-label="Footer">
+          <ul class="footer__nav">
+            <li><a href="about.html">About</a></li>
+            <li><a href="insights.html">Insights</a></li>
+            <li><a href="projects.html">Projects</a></li>
+            <li><a href="podcasts.html">Podcasts</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </nav>
+      </div>
+      <p class="footer__legal">© <span data-year></span> Raju Thoutu · Crafted with clarity and conscience.</p>
+    </footer>
+
+    <script src="assets/js/main.js" defer></script>
+  </body>
+</html>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,38 +1,37 @@
-html {
-  scroll-behavior: smooth;
-}
-
 :root {
-  --color-background: #f6f7fb;
-  --color-surface: #ffffff;
-  --color-muted: #6d6e75;
-  --color-text: #151724;
-  --color-accent: #5b55ff;
-  --color-accent-soft: rgba(91, 85, 255, 0.12);
-  --color-border: rgba(26, 31, 53, 0.08);
-  --color-highlight: #ecf0ff;
-  --shadow-soft: 0 20px 60px -30px rgba(15, 20, 44, 0.28);
-  --radius-large: 32px;
-  --radius-medium: 20px;
-  --radius-small: 14px;
-  --container-width: min(1120px, 92vw);
-  --transition-base: 220ms ease;
-  --font-heading: "Space Grotesk", system-ui, sans-serif;
-  --font-body: "DM Sans", system-ui, sans-serif;
   color-scheme: light;
+  --font-sans: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-alt: "Poppins", "Inter", system-ui, sans-serif;
+  --color-background: #f5f6fa;
+  --color-surface: rgba(255, 255, 255, 0.92);
+  --color-surface-strong: #ffffff;
+  --color-text: #10121a;
+  --color-muted: #495065;
+  --color-border: rgba(16, 18, 26, 0.08);
+  --color-accent: #1463ff; /* electric blue */
+  --color-accent-soft: rgba(20, 99, 255, 0.08);
+  --color-saffron: #ff7a1a;
+  --radius-large: 28px;
+  --radius-medium: 18px;
+  --radius-small: 12px;
+  --shadow-soft: 0 30px 60px -40px rgba(17, 27, 66, 0.45);
+  --container-max: min(1200px, 92vw);
+  --transition: 220ms ease;
+  background-color: var(--color-background);
 }
 
 [data-theme="dark"] {
-  --color-background: #05060f;
-  --color-surface: #0f1020;
-  --color-muted: #b1b6d3;
-  --color-text: #f3f4fb;
-  --color-accent: #8f88ff;
-  --color-accent-soft: rgba(143, 136, 255, 0.14);
-  --color-border: rgba(123, 130, 160, 0.18);
-  --color-highlight: rgba(143, 136, 255, 0.1);
-  --shadow-soft: 0 18px 60px -28px rgba(0, 0, 0, 0.55);
   color-scheme: dark;
+  --color-background: #07070c;
+  --color-surface: rgba(17, 19, 28, 0.92);
+  --color-surface-strong: #131521;
+  --color-text: #f4f5ff;
+  --color-muted: #c1c4d9;
+  --color-border: rgba(244, 245, 255, 0.08);
+  --color-accent: #3f8cff;
+  --color-accent-soft: rgba(63, 140, 255, 0.18);
+  --color-saffron: #ff9940;
+  --shadow-soft: 0 24px 80px -48px rgba(0, 0, 0, 0.85);
 }
 
 * {
@@ -41,43 +40,33 @@ html {
 
 body {
   margin: 0;
-  font-family: var(--font-body);
-  font-size: 1.05rem;
-  line-height: 1.7;
+  font-family: var(--font-sans);
+  font-size: 1rem;
+  line-height: 1.65;
   color: var(--color-text);
-  background: radial-gradient(circle at 15% 15%, rgba(91, 85, 255, 0.08), transparent 55%),
-    radial-gradient(circle at 80% 10%, rgba(255, 115, 179, 0.1), transparent 50%),
+  background: radial-gradient(circle at 5% 5%, rgba(20, 99, 255, 0.16), transparent 55%),
+    radial-gradient(circle at 90% 10%, rgba(255, 122, 26, 0.18), transparent 45%),
     var(--color-background);
-  transition: background 420ms ease, color 420ms ease;
+  min-height: 100vh;
+  transition: background 360ms ease, color 360ms ease;
 }
 
-img {
+img,
+iframe {
   max-width: 100%;
+  border: 0;
   display: block;
 }
 
-h1,
- h2,
- h3,
- h4 {
-  font-family: var(--font-heading);
-  letter-spacing: -0.02em;
-  margin-top: 0;
-  color: var(--color-text);
+a {
+  color: inherit;
+  text-decoration: none;
+  transition: color var(--transition);
 }
 
-h1 {
-  font-size: clamp(2.5rem, 4vw, 3.6rem);
-  line-height: 1.1;
-}
-
-h2 {
-  font-size: clamp(2rem, 3.2vw, 2.8rem);
-  line-height: 1.2;
-}
-
-h3 {
-  font-size: 1.4rem;
+a:hover,
+a:focus-visible {
+  color: var(--color-accent);
 }
 
 p {
@@ -85,871 +74,929 @@ p {
   color: var(--color-muted);
 }
 
-a {
-  color: inherit;
-  text-decoration: none;
+h1,
+h2,
+h3,
+h4,
+h5 {
+  font-family: var(--font-alt);
+  color: var(--color-text);
+  margin: 0 0 1.1rem;
+  letter-spacing: -0.01em;
 }
 
-a:hover,
- a:focus {
-  color: var(--color-accent);
+h1 {
+  font-size: clamp(2.4rem, 4vw, 3.2rem);
+  line-height: 1.12;
+}
+
+h2 {
+  font-size: clamp(1.9rem, 3vw, 2.4rem);
+}
+
+h3 {
+  font-size: clamp(1.25rem, 2.2vw, 1.55rem);
+}
+
+h4 {
+  font-size: 1.1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
 }
 
 .container {
-  width: var(--container-width);
+  width: var(--container-max);
   margin: 0 auto;
 }
 
-.section-heading {
-  max-width: 680px;
-  margin-bottom: 3rem;
+.container.narrow {
+  max-width: 780px;
 }
 
-.section-heading--center {
-  text-align: center;
-  margin-left: auto;
-  margin-right: auto;
+.section {
+  padding: clamp(3rem, 8vw, 4.5rem) 0;
 }
 
-.section-heading--center p {
-  margin-left: auto;
-  margin-right: auto;
+.section--surface {
+  background: var(--color-surface);
+  backdrop-filter: blur(14px);
 }
 
-.section-heading p:last-child {
-  margin-bottom: 0;
+.section__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 1.5rem;
+  margin-bottom: 2.5rem;
+}
+
+.section__cta {
+  font-weight: 600;
+  color: var(--color-accent);
 }
 
 .eyebrow {
   font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.3em;
   text-transform: uppercase;
-  letter-spacing: 0.24em;
-  font-weight: 700;
-  color: var(--color-accent);
-  margin-bottom: 0.75rem;
+  color: var(--color-saffron);
+  margin-bottom: 0.6rem;
+}
+
+.lead {
+  font-size: 1.1rem;
+  color: var(--color-muted);
 }
 
 .btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.5rem;
-  font-weight: 600;
+  gap: 0.4rem;
+  padding: 0.85rem 1.8rem;
   border-radius: 999px;
-  padding: 0.8rem 1.6rem;
-  transition: transform var(--transition-base), box-shadow var(--transition-base), color var(--transition-base), background var(--transition-base);
-  cursor: pointer;
-  font-family: var(--font-heading);
+  font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.12em;
-  font-size: 0.85rem;
+  font-size: 0.8rem;
+  border: 1px solid transparent;
+  transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
+  cursor: pointer;
 }
 
 .btn:focus-visible {
   outline: 3px solid var(--color-accent);
-  outline-offset: 2px;
+  outline-offset: 3px;
 }
 
 .btn--primary {
-  background: var(--color-accent);
+  background: linear-gradient(135deg, var(--color-accent), var(--color-saffron));
   color: #fff;
-  box-shadow: 0 16px 32px -18px rgba(91, 85, 255, 0.8);
+  box-shadow: var(--shadow-soft);
 }
 
-.btn--primary:hover,
-.btn--primary:focus-visible {
+.btn--primary:hover {
   transform: translateY(-2px);
-  box-shadow: 0 22px 42px -18px rgba(91, 85, 255, 0.65);
+}
+
+.btn--secondary {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+  background: transparent;
+}
+
+.btn--secondary:hover {
+  background: var(--color-accent-soft);
 }
 
 .btn--ghost {
-  border: 1px solid var(--color-border);
+  border-color: var(--color-border);
   background: transparent;
-  color: var(--color-text);
 }
 
-.btn--ghost:hover,
-.btn--ghost:focus-visible {
+.btn--ghost:hover {
   border-color: var(--color-accent);
   color: var(--color-accent);
 }
 
-.skip-link {
-  position: absolute;
-  left: -999px;
-  top: 1rem;
-  background: var(--color-accent);
-  color: #fff;
-  padding: 0.75rem 1.25rem;
-  border-radius: 999px;
-  font-weight: 600;
-  text-decoration: none;
-  z-index: 1000;
-  transition: transform var(--transition-base);
-}
-
-.skip-link:focus {
-  left: 1rem;
-  transform: translateY(0);
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 2rem;
 }
 
 .site-header {
   position: sticky;
   top: 0;
   z-index: 999;
-  backdrop-filter: blur(14px);
-  background: rgba(246, 247, 251, 0.75);
-  padding: 1.1rem 0;
+  backdrop-filter: blur(16px);
+  background: color-mix(in srgb, var(--color-surface) 88%, transparent);
   border-bottom: 1px solid var(--color-border);
-  transition: background var(--transition-base), border-color var(--transition-base);
 }
 
-[data-theme="dark"] .site-header {
-  background: rgba(5, 6, 15, 0.8);
-}
-
-.header-inner {
+.header__inner {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 1.5rem;
+  padding: 1.1rem 0;
 }
 
-.logo {
+.brand {
   display: inline-flex;
   align-items: center;
-  gap: 0.7rem;
-  font-family: var(--font-heading);
-  font-weight: 700;
-  font-size: 1.1rem;
-  padding: 0.4rem 0.75rem;
-  border-radius: 999px;
-  background: var(--color-highlight);
-  color: var(--color-text);
+  gap: 0.75rem;
+  font-weight: 600;
 }
 
-.logo span {
-  font-size: 0.85rem;
+.brand__mark {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-size: 1.35rem;
+  background: linear-gradient(135deg, var(--color-accent), var(--color-saffron));
+  color: #fff;
+}
+
+.brand__text {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.brand__title {
+  font-size: 0.95rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.brand__tagline {
+  font-size: 0.75rem;
+  color: var(--color-muted);
+}
+
+.brand--small .brand__mark {
+  width: 36px;
+  height: 36px;
+  font-size: 1rem;
+}
+
+.site-nav__list {
+  list-style: none;
+  display: flex;
+  gap: 1.5rem;
+  padding: 0;
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.site-nav__list a[aria-current="page"] {
   color: var(--color-accent);
-}
-
-.site-nav {
-  position: relative;
+  font-weight: 600;
 }
 
 .nav-toggle {
   display: none;
   background: none;
-  border: none;
-  padding: 0.6rem;
+  border: 0;
+  padding: 0.4rem;
   cursor: pointer;
-  border-radius: 12px;
-  transition: background var(--transition-base);
-}
-
-.nav-toggle:hover,
-.nav-toggle:focus-visible {
-  background: var(--color-highlight);
 }
 
 .nav-toggle__line {
-  display: block;
   width: 24px;
   height: 2px;
   background: var(--color-text);
-  margin: 4px 0;
-  transition: transform var(--transition-base), opacity var(--transition-base);
-}
-
-.nav-list {
-  display: flex;
-  align-items: center;
-  gap: 1.8rem;
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  font-weight: 600;
-  font-size: 0.95rem;
-}
-
-.nav-list a {
-  position: relative;
-  padding: 0.2rem 0;
-}
-
-.nav-list a::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: -0.4rem;
-  height: 2px;
-  background: var(--color-accent);
-  transform: scaleX(0);
-  transform-origin: left;
-  transition: transform var(--transition-base);
-  opacity: 0.9;
-}
-
-.nav-list a:hover::after,
-.nav-list a:focus::after {
-  transform: scaleX(1);
+  display: block;
+  margin: 5px 0;
+  transition: transform var(--transition);
 }
 
 .theme-toggle {
-  background: var(--color-highlight);
-  border: none;
-  border-radius: 999px;
-  padding: 0.45rem;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  display: grid;
+  place-items: center;
   cursor: pointer;
-  transition: transform var(--transition-base), background var(--transition-base);
-}
-
-.theme-toggle:hover,
-.theme-toggle:focus-visible {
-  transform: translateY(-2px);
-  background: var(--color-accent-soft);
+  transition: background var(--transition), border-color var(--transition);
 }
 
 .theme-toggle__icon {
-  width: 32px;
-  height: 32px;
-  fill: none;
-  stroke: none;
-}
-
-.theme-toggle__sun {
-  fill: var(--color-accent);
-  transition: opacity var(--transition-base), transform var(--transition-base);
-}
-
-.theme-toggle__moon {
-  fill: var(--color-text);
-  transition: opacity var(--transition-base), transform var(--transition-base);
-}
-
-[data-theme="dark"] .theme-toggle__sun {
-  opacity: 0.2;
-  transform: scale(0.6);
-}
-
-[data-theme="dark"] .theme-toggle__moon {
-  fill: var(--color-accent);
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, var(--color-accent), transparent 70%),
+    conic-gradient(from 180deg at 50% 50%, transparent 0 180deg, var(--color-text) 180deg 360deg);
+  mix-blend-mode: screen;
 }
 
 .hero {
-  padding: 6rem 0 4rem;
+  padding: clamp(3rem, 9vw, 5rem) 0;
 }
 
-.hero__inner {
+.hero__grid {
   display: grid;
-  gap: 3rem;
-  align-items: center;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(12, 1fr);
+  gap: 2.5rem;
+  align-items: stretch;
 }
 
-.hero__lead {
-  font-size: 1.15rem;
+.hero__content {
+  grid-column: span 8;
+}
+
+.hero__metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1.5rem;
+  margin-top: 2rem;
+}
+
+.hero__metrics dt {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
   color: var(--color-muted);
 }
 
-.hero__actions {
-  display: flex;
+.hero__metrics dd {
+  font-size: 1.8rem;
+  font-weight: 600;
+  margin: 0.3rem 0 0;
+}
+
+.founder-card {
+  grid-column: span 4;
+  background: var(--color-surface);
+  border-radius: var(--radius-large);
+  padding: 2.2rem;
+  box-shadow: var(--shadow-soft);
+  display: grid;
   gap: 1rem;
-  flex-wrap: wrap;
+}
+
+.founder-card__avatar {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--color-saffron), var(--color-accent));
+  display: grid;
+  place-items: center;
+  color: #fff;
+  font-weight: 700;
+  font-size: 1.2rem;
+}
+
+.founder-card__role {
+  color: var(--color-accent);
+  font-weight: 600;
+}
+
+.founder-card__link {
+  font-weight: 600;
+  color: var(--color-accent);
+}
+
+.quick-nav {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.quick-nav__card {
+  border-radius: var(--radius-medium);
+  padding: 1.6rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  display: grid;
+  gap: 0.6rem;
+  min-height: 160px;
+  transition: transform var(--transition), border-color var(--transition), box-shadow var(--transition);
+}
+
+.quick-nav__card:hover {
+  transform: translateY(-6px);
+  border-color: var(--color-accent);
+  box-shadow: var(--shadow-soft);
+}
+
+.quick-nav__label {
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.quick-nav__meta {
+  font-size: 0.95rem;
+}
+
+.signature-quote {
+  padding: clamp(3rem, 8vw, 4.5rem) 0;
+  background: radial-gradient(circle at 80% 20%, rgba(20, 99, 255, 0.15), transparent 60%), var(--color-surface-strong);
+  text-align: center;
+}
+
+.signature-quote blockquote {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.1rem);
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.signature-quote cite {
+  display: block;
+  margin-top: 1.5rem;
+  font-size: 0.95rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--color-accent);
+}
+
+.card-grid {
+  display: grid;
+  gap: 1.8rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.content-card {
+  background: var(--color-surface);
+  border-radius: var(--radius-medium);
+  padding: 1.9rem;
+  display: grid;
+  gap: 0.8rem;
+  border: 1px solid var(--color-border);
+  transition: box-shadow var(--transition), transform var(--transition);
+}
+
+.content-card:hover {
+  transform: translateY(-6px);
+  box-shadow: var(--shadow-soft);
+}
+
+.content-card__eyebrow {
+  font-size: 0.78rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--color-accent);
+}
+
+.content-card__link {
+  font-weight: 600;
+  color: var(--color-accent);
+}
+
+.newsletter {
+  display: grid;
+  gap: 2rem;
+  align-items: center;
+}
+
+.newsletter__form {
+  display: grid;
+  gap: 1rem;
+  align-items: center;
+  grid-template-columns: repeat(auto-fit, minmax(200px, max-content));
+}
+
+.newsletter__input {
+  width: min(320px, 100%);
+  padding: 0.9rem 1.1rem;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  background: #fff;
+  font-size: 1rem;
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+.newsletter__input:focus-visible {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--color-accent-soft);
+  outline: none;
+}
+
+.newsletter__feedback {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--color-accent);
+}
+
+.site-footer {
+  padding: 3rem 0 2rem;
+  background: color-mix(in srgb, var(--color-surface) 82%, transparent);
+  border-top: 1px solid var(--color-border);
+  text-align: center;
+}
+
+.footer__grid {
+  display: grid;
+  gap: 1.5rem;
+  justify-items: center;
   margin-bottom: 1.5rem;
 }
 
-.hero__stats {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 1.4rem;
-  margin: 2rem 0 0;
-  padding: 1.4rem;
-  border-radius: var(--radius-medium);
-  background: var(--color-surface);
-  box-shadow: var(--shadow-soft);
-}
-
-.hero__stats div {
-  text-align: left;
-}
-
-.hero__stats dt {
-  font-size: 0.85rem;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--color-muted);
-  margin-bottom: 0.35rem;
-}
-
-.hero__stats dd {
-  margin: 0;
-  font-size: 1.8rem;
-  font-weight: 700;
-  color: var(--color-text);
-}
-
-.hero__visual {
-  position: relative;
-  padding: 3rem;
-  border-radius: var(--radius-large);
-  background: linear-gradient(140deg, rgba(91, 85, 255, 0.18), rgba(255, 120, 170, 0.18));
-  box-shadow: var(--shadow-soft);
-}
-
-.hero__visual::after {
-  content: "";
-  position: absolute;
-  inset: 18px;
-  border-radius: var(--radius-medium);
-  border: 1px dashed rgba(255, 255, 255, 0.25);
-  pointer-events: none;
-}
-
-.pillars {
-  padding: 5rem 0;
-}
-
-.pillars__layout {
-  display: grid;
-  grid-template-columns: minmax(0, 220px) minmax(0, 1fr);
-  gap: 2.2rem;
-}
-
-.pillars__tabs {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.pillars__tab {
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-small);
-  padding: 0.85rem 1rem;
-  font-weight: 600;
-  font-family: var(--font-heading);
-  text-align: left;
-  cursor: pointer;
-  color: var(--color-muted);
-  transition: background var(--transition-base), border-color var(--transition-base), color var(--transition-base);
-}
-
-.pillars__tab.is-active,
-.pillars__tab:hover,
-.pillars__tab:focus-visible {
-  background: var(--color-highlight);
-  border-color: var(--color-accent);
-  color: var(--color-text);
-}
-
-.pillars__panels {
-  position: relative;
-}
-
-.pillars__panel {
-  background: var(--color-surface);
-  border-radius: var(--radius-large);
-  padding: 2.6rem;
-  box-shadow: var(--shadow-soft);
-  border: 1px solid var(--color-border);
-  transition: opacity var(--transition-base), transform var(--transition-base);
-  opacity: 0;
-  transform: translateY(20px);
-  position: absolute;
-  inset: 0;
-}
-
-.pillars__panel.is-active {
-  opacity: 1;
-  transform: translateY(0);
-  position: relative;
-  z-index: 2;
-}
-
-.pillars__list {
+.footer__nav {
   list-style: none;
-  margin: 2rem 0 0;
-  padding: 0;
-  display: grid;
-  gap: 0.8rem;
-}
-
-.pillars__list li {
-  position: relative;
-  padding-left: 1.4rem;
-  color: var(--color-muted);
-}
-
-.pillars__list li::before {
-  content: "";
-  position: absolute;
-  left: 0;
-  top: 0.65rem;
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--color-accent);
-}
-
-.podcast {
-  padding: 5rem 0;
-}
-
-.podcast__grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  display: flex;
   gap: 1.5rem;
+  padding: 0;
+  margin: 0;
+  font-size: 0.95rem;
 }
 
-.podcast__card {
-  background: var(--color-surface);
-  border-radius: var(--radius-medium);
-  padding: 2.2rem 2rem;
-  border: 1px solid var(--color-border);
-  box-shadow: var(--shadow-soft);
-  display: flex;
-  flex-direction: column;
-  gap: 0.9rem;
-  min-height: 100%;
+.footer__tagline {
+  margin: 0.6rem 0 0;
 }
 
-.podcast__meta {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
+.footer__legal {
+  margin: 0;
   font-size: 0.85rem;
   color: var(--color-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
 }
 
-.podcast__tag {
-  background: var(--color-accent-soft);
-  color: var(--color-accent);
-  border-radius: 999px;
-  padding: 0.35rem 0.8rem;
-  font-weight: 600;
+.page {
+  padding-bottom: 4rem;
 }
 
-.podcast__link {
-  margin-top: auto;
-  font-weight: 600;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  color: var(--color-accent);
+.page-hero {
+  padding: clamp(3rem, 9vw, 5rem) 0 2rem;
 }
 
-.podcast__link::after {
-  content: "\2192";
-  transition: transform var(--transition-base);
+.page-hero .lead {
+  max-width: 720px;
 }
 
-.podcast__link:hover::after,
-.podcast__link:focus::after {
-  transform: translateX(4px);
-}
-
-.insights {
-  padding: 5rem 0;
-}
-
-.insights__filters {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-  margin-bottom: 2rem;
-}
-
-.insights__filter {
-  border: 1px solid var(--color-border);
-  border-radius: 999px;
-  padding: 0.55rem 1.2rem;
-  font-size: 0.9rem;
-  background: transparent;
-  cursor: pointer;
-  color: var(--color-muted);
-  transition: background var(--transition-base), color var(--transition-base), border-color var(--transition-base);
-}
-
-.insights__filter.is-active,
-.insights__filter:hover,
-.insights__filter:focus-visible {
-  background: var(--color-highlight);
-  color: var(--color-text);
-  border-color: var(--color-accent);
-}
-
-.insights__grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 1.5rem;
-}
-
-.insight-card {
-  background: var(--color-surface);
-  border-radius: var(--radius-medium);
-  border: 1px solid var(--color-border);
-  padding: 2.2rem 2rem;
-  box-shadow: var(--shadow-soft);
-  display: flex;
-  flex-direction: column;
-  gap: 0.9rem;
-  transition: transform var(--transition-base), box-shadow var(--transition-base), opacity var(--transition-base);
-}
-
-.insight-card[hidden] {
-  display: none;
-}
-
-.insight-card:hover {
-  transform: translateY(-6px);
-  box-shadow: 0 28px 44px -30px rgba(91, 85, 255, 0.45);
-}
-
-.insight-card__link {
-  margin-top: auto;
-  font-weight: 600;
-  color: var(--color-accent);
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-}
-
-.insight-card__link::after {
-  content: "\2192";
-  transition: transform var(--transition-base);
-}
-
-.insight-card__link:hover::after,
-.insight-card__link:focus::after {
-  transform: translateX(4px);
-}
-
-.events {
-  padding: 5.5rem 0;
-}
-
-.events__inner {
-  background: linear-gradient(135deg, rgba(91, 85, 255, 0.18), rgba(255, 115, 179, 0.18));
-  border-radius: var(--radius-large);
-  padding: clamp(2.4rem, 4vw, 3.6rem);
+.split {
   display: grid;
   gap: 3rem;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  border: 1px solid rgba(255, 255, 255, 0.3);
-  position: relative;
-  overflow: hidden;
 }
 
-.events__inner::before {
-  content: "";
-  position: absolute;
-  inset: 1.2rem;
-  border-radius: calc(var(--radius-large) - 14px);
-  border: 1px dashed rgba(255, 255, 255, 0.35);
-  pointer-events: none;
-}
-
-.events__content,
-.events__card {
-  position: relative;
-  z-index: 2;
-}
-
-.events__list {
+.timeline,
+.vision-list {
   list-style: none;
-  margin: 1.8rem 0 2.2rem;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.timeline li,
+.vision-list li {
+  background: var(--color-surface);
+  padding: 1.2rem 1.4rem;
+  border-radius: var(--radius-small);
+  border: 1px solid var(--color-border);
+}
+
+.insights__layout {
+  display: grid;
+  grid-template-columns: minmax(220px, 320px) 1fr;
+  gap: 2.5rem;
+}
+
+.insights__sidebar {
+  position: sticky;
+  top: 108px;
+  align-self: start;
+  max-height: calc(100vh - 120px);
+  overflow-y: auto;
+  padding-right: 0.5rem;
+  scrollbar-width: thin;
+}
+
+.search {
+  margin-bottom: 1.5rem;
+  background: var(--color-surface);
+  border-radius: var(--radius-medium);
+  padding: 1.2rem;
+  border: 1px solid var(--color-border);
+}
+
+.search__label {
+  display: block;
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin-bottom: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--color-muted);
+}
+
+.search input {
+  width: 100%;
+  padding: 0.75rem 0.9rem;
+  border-radius: var(--radius-small);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-strong);
+  color: var(--color-text);
+}
+
+.side-nav__section {
+  border-radius: var(--radius-medium);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  margin-bottom: 1.2rem;
+  padding: 0.4rem 0.8rem;
+}
+
+.side-nav__section summary {
+  cursor: pointer;
+  font-weight: 600;
+  list-style: none;
+  padding: 0.6rem 0.4rem;
+}
+
+.side-nav__content {
+  display: grid;
+  gap: 0.4rem;
+  padding: 0.4rem 0.4rem 0.8rem 0.4rem;
+}
+
+.side-nav__hint {
+  margin: 0.6rem 0 0.2rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--color-muted);
+}
+
+.side-nav__content ul {
+  list-style: none;
+  margin: 0;
   padding: 0;
   display: grid;
-  gap: 0.8rem;
-  color: var(--color-text);
+  gap: 0.3rem;
 }
 
-.events__list strong {
-  font-weight: 700;
-  color: var(--color-text);
+.side-nav__content button,
+.side-nav__content a {
+  text-align: left;
+  padding: 0.5rem 0.6rem;
+  border-radius: var(--radius-small);
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  transition: background var(--transition), color var(--transition);
 }
 
-.events__card {
-  background: rgba(255, 255, 255, 0.55);
+.side-nav__content button:hover,
+.side-nav__content button:focus-visible,
+.side-nav__content a:hover,
+.side-nav__content a:focus-visible {
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+}
+
+.tag-cloud {
+  margin-top: 2rem;
+  background: var(--color-surface);
   border-radius: var(--radius-medium);
+  border: 1px solid var(--color-border);
+  padding: 1rem 1.2rem;
+}
+
+.tag-cloud__title {
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.tag-cloud__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.tag-cloud__chips button {
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  padding: 0.45rem 1rem;
+  background: transparent;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.tag-cloud__chips button:hover,
+.tag-cloud__chips button:focus-visible {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+.insights__content {
+  display: grid;
+  gap: 2rem;
+}
+
+.insights__controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1rem;
+  justify-content: space-between;
+}
+
+.insight-list {
+  display: grid;
+  gap: 2rem;
+}
+
+.insight-item {
+  background: var(--color-surface);
+  border-radius: var(--radius-large);
+  padding: 2rem 2.4rem;
+  border: 1px solid var(--color-border);
+  box-shadow: 0 12px 40px -30px rgba(20, 35, 80, 0.35);
+  display: grid;
+  gap: 0.9rem;
+}
+
+.insight-item__meta {
+  font-size: 0.82rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--color-accent);
+}
+
+.insight-item__tags {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  padding: 0;
+  margin: 0;
+}
+
+.insight-item__tags li {
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  background: var(--color-accent-soft);
+  font-size: 0.8rem;
+  color: var(--color-accent);
+}
+
+.project-grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.project-card {
+  background: var(--color-surface);
+  border-radius: var(--radius-large);
   padding: 2.2rem;
-  backdrop-filter: blur(8px);
+  border: 1px solid var(--color-border);
   box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 1rem;
+}
+
+.project-card__category {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--color-accent);
+}
+
+.project-card__summary {
+  font-weight: 600;
+  color: var(--color-muted);
+}
+
+.project-card__link {
+  font-weight: 600;
+  color: var(--color-accent);
+}
+
+.video-hub {
+  display: grid;
+  gap: 3rem;
+}
+
+.video-feature {
+  background: var(--color-surface);
+  border-radius: var(--radius-large);
+  padding: 2.2rem;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 1rem;
+}
+
+.video-feature__category {
+  font-size: 0.8rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--color-saffron);
+}
+
+.video-frame {
+  position: relative;
+  width: 100%;
+  padding-top: 56.25%;
+  border-radius: var(--radius-medium);
+  overflow: hidden;
+  background: #000;
+}
+
+.video-frame iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.playlist {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.playlist__grid {
+  display: grid;
+  gap: 1.8rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.playlist__item {
+  background: var(--color-surface);
+  border-radius: var(--radius-medium);
+  padding: 1.4rem;
+  border: 1px solid var(--color-border);
+  display: grid;
+  gap: 0.8rem;
+}
+
+.pagination-hint {
+  display: grid;
+  gap: 0.6rem;
+  justify-items: start;
+}
+
+.pagination-hint__note {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--color-muted);
+}
+
+.contact-grid {
+  display: grid;
+  gap: 2.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.contact-form {
+  background: var(--color-surface);
+  padding: 2rem;
+  border-radius: var(--radius-large);
+  border: 1px solid var(--color-border);
   display: grid;
   gap: 1.2rem;
 }
 
-[data-theme="dark"] .events__card {
-  background: rgba(15, 16, 32, 0.65);
+.form-group {
+  display: grid;
+  gap: 0.5rem;
 }
 
-.events__card-list {
+.form-group input,
+.form-group textarea {
+  border-radius: var(--radius-small);
+  border: 1px solid var(--color-border);
+  padding: 0.85rem 1rem;
+  font: inherit;
+  background: var(--color-surface-strong);
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+.form-group textarea {
+  resize: vertical;
+}
+
+.form-group input:focus-visible,
+.form-group textarea:focus-visible {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--color-accent-soft);
+  outline: none;
+}
+
+.form-feedback {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--color-accent);
+}
+
+.contact-info {
+  display: grid;
+  gap: 1rem;
+}
+
+.contact-links {
   list-style: none;
   padding: 0;
   margin: 0;
   display: grid;
   gap: 0.6rem;
-  color: var(--color-muted);
 }
 
-.events__card-list li::before {
-  content: "\2713";
-  margin-right: 0.6rem;
-  color: var(--color-accent);
-}
-
-.events__card-link {
-  font-weight: 600;
-  color: var(--color-accent);
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-}
-
-.events__card-link::after {
-  content: "\2192";
-  transition: transform var(--transition-base);
-}
-
-.events__card-link:hover::after,
-.events__card-link:focus::after {
-  transform: translateX(4px);
-}
-
-.newsletter {
-  padding: 5rem 0;
-}
-
-.newsletter__inner {
-  background: var(--color-surface);
-  border-radius: var(--radius-large);
-  box-shadow: var(--shadow-soft);
-  border: 1px solid var(--color-border);
-  padding: 3rem clamp(2rem, 5vw, 4rem);
+.article__layout {
   display: grid;
-  gap: 3rem;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 2.5rem;
+  grid-template-columns: minmax(180px, 220px) 1fr;
   align-items: start;
+  padding: 3rem 0;
 }
 
-.newsletter__badges {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-}
-
-.newsletter__badges span {
-  padding: 0.4rem 0.9rem;
-  border-radius: 999px;
-  background: var(--color-highlight);
-  font-weight: 600;
-  color: var(--color-text);
-}
-
-.newsletter__form {
+.article__header {
+  grid-column: 1 / -1;
   display: grid;
-  gap: 0.85rem;
+  gap: 0.6rem;
 }
 
-.newsletter__feedback {
-  min-height: 1.2rem;
-  font-size: 0.85rem;
-  color: var(--color-accent);
-  margin: 0;
-}
-
-.newsletter__label {
-  font-size: 0.85rem;
+.article__category {
+  font-size: 0.82rem;
+  letter-spacing: 0.2em;
   text-transform: uppercase;
-  letter-spacing: 0.18em;
-  font-weight: 700;
+  color: var(--color-accent);
+}
+
+.article__meta {
+  font-size: 0.9rem;
   color: var(--color-muted);
 }
 
-.newsletter__form input,
-.newsletter__form textarea {
-  width: 100%;
-  border-radius: var(--radius-small);
-  border: 1px solid var(--color-border);
-  padding: 0.9rem 1rem;
-  font-size: 1rem;
-  font-family: var(--font-body);
-  background: rgba(255, 255, 255, 0.9);
-  color: var(--color-text);
-  transition: border-color var(--transition-base), box-shadow var(--transition-base);
-}
-
-[data-theme="dark"] .newsletter__form input,
-[data-theme="dark"] .newsletter__form textarea {
-  background: rgba(14, 16, 30, 0.95);
-}
-
-.newsletter__form input:focus,
-.newsletter__form textarea:focus {
-  outline: none;
-  border-color: var(--color-accent);
-  box-shadow: 0 0 0 4px var(--color-accent-soft);
-}
-
-.newsletter__smallprint {
-  font-size: 0.8rem;
-  color: var(--color-muted);
-  margin: 0;
-}
-
-.faq {
-  padding: 5rem 0 6rem;
-}
-
-.faq__list {
-  display: grid;
-  gap: 1rem;
-  max-width: 820px;
-  margin: 0 auto;
-}
-
-.faq__item {
+.article__toc {
+  position: sticky;
+  top: 120px;
+  align-self: start;
   background: var(--color-surface);
   border-radius: var(--radius-medium);
   border: 1px solid var(--color-border);
+  padding: 1.4rem;
+}
+
+.article__toc-title {
+  font-weight: 600;
+  margin: 0 0 0.8rem;
+}
+
+.article__toc ol {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: var(--color-muted);
+  display: grid;
+  gap: 0.4rem;
+}
+
+.article__body {
+  background: var(--color-surface);
+  border-radius: var(--radius-large);
+  border: 1px solid var(--color-border);
+  padding: 2.4rem;
+  display: grid;
+  gap: 2rem;
   box-shadow: var(--shadow-soft);
 }
 
-.faq__item h3 {
-  margin: 0;
-}
-
-.faq__item button {
-  width: 100%;
-  border: none;
-  background: none;
-  text-align: left;
-  font: inherit;
-  font-weight: 600;
-  padding: 1.2rem 1.4rem;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  cursor: pointer;
+.article__body blockquote {
+  border-left: 4px solid var(--color-accent);
+  margin: 1rem 0;
+  padding-left: 1.2rem;
   color: var(--color-text);
+  font-style: italic;
 }
 
-.faq__item button:hover,
-.faq__item button:focus-visible {
-  background: var(--color-highlight);
-}
-
-.faq__icon {
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  background: var(--color-accent-soft);
-  position: relative;
-  flex-shrink: 0;
-}
-
-.faq__icon::before,
-.faq__icon::after {
-  content: "";
-  position: absolute;
-  background: var(--color-accent);
-  border-radius: 2px;
-}
-
-.faq__icon::before {
-  width: 10px;
-  height: 2px;
-  top: 9px;
-  left: 5px;
-}
-
-.faq__icon::after {
-  width: 2px;
-  height: 10px;
-  top: 5px;
-  left: 9px;
-  transition: transform var(--transition-base);
-}
-
-.faq__item.is-open .faq__icon::after {
-  transform: scaleY(0);
-}
-
-.faq__body {
-  display: none;
-  padding: 0 1.4rem 1.4rem;
-  color: var(--color-muted);
-}
-
-.faq__item.is-open .faq__body {
-  display: block;
-}
-
-.site-footer {
-  background: var(--color-surface);
-  border-top: 1px solid var(--color-border);
-  padding: 3.4rem 0 2rem;
-}
-
-.site-footer__inner {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 2.5rem;
-}
-
-.site-footer__brand p {
-  color: var(--color-muted);
-}
-
-.site-footer__links {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  gap: 1.4rem;
-}
-
-.site-footer__links h3 {
-  font-size: 0.95rem;
-  text-transform: uppercase;
-  letter-spacing: 0.15em;
-  margin-bottom: 0.85rem;
-}
-
-.site-footer__links ul {
-  list-style: none;
+.article__body ul,
+.article__body ol {
+  padding-left: 1.1rem;
   margin: 0;
-  padding: 0;
-  display: grid;
-  gap: 0.5rem;
-}
-
-.site-footer__links a {
   color: var(--color-muted);
-}
-
-.site-footer__links a:hover,
-.site-footer__links a:focus {
-  color: var(--color-accent);
-}
-
-.site-footer__bottom {
-  margin-top: 2.4rem;
-  border-top: 1px solid var(--color-border);
-  padding-top: 1.6rem;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 1rem;
-  color: var(--color-muted);
-}
-
-.site-footer__top {
-  font-weight: 600;
-  color: var(--color-accent);
 }
 
 .sr-only {
@@ -963,130 +1010,77 @@ a:hover,
   border: 0;
 }
 
-@media (max-width: 960px) {
-  .hero__inner {
+@media (max-width: 980px) {
+  .hero__grid {
     grid-template-columns: 1fr;
   }
 
-  .hero__visual {
-    order: -1;
+  .founder-card {
+    grid-column: span 12;
   }
 
-  .hero__stats {
-    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  }
-
-  .pillars__layout {
+  .insights__layout,
+  .article__layout {
     grid-template-columns: 1fr;
   }
 
-  .pillars__tabs {
-    flex-direction: row;
-    flex-wrap: wrap;
-    justify-content: center;
+  .insights__sidebar,
+  .article__toc {
+    position: static;
+    max-height: none;
   }
 
-  .pillars__panel {
-    position: relative;
-    opacity: 1;
-    transform: none;
-  }
-
-  .pillars__panel:not(.is-active) {
-    display: none;
-  }
-
-  .newsletter__inner {
-    grid-template-columns: 1fr;
+  .article__body {
+    padding: 1.8rem;
   }
 }
 
-@media (max-width: 760px) {
-  body {
-    font-size: 1rem;
+@media (max-width: 840px) {
+  .site-nav__list {
+    position: fixed;
+    inset: 0 0 0 auto;
+    background: var(--color-surface-strong);
+    padding: 5rem 2.5rem;
+    flex-direction: column;
+    transform: translateX(100%);
+    transition: transform var(--transition);
+    min-width: 260px;
+    box-shadow: -24px 0 40px -32px rgba(9, 16, 35, 0.4);
   }
 
-  .site-header {
-    padding: 0.8rem 0;
+  .site-nav__list.is-open {
+    transform: translateX(0);
   }
 
   .nav-toggle {
-    display: inline-flex;
+    display: block;
   }
 
-  .nav-list {
-    position: absolute;
-    top: calc(100% + 0.75rem);
-    right: 0;
-    background: var(--color-surface);
-    border-radius: var(--radius-medium);
-    box-shadow: var(--shadow-soft);
-    border: 1px solid var(--color-border);
-    padding: 1.2rem;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 1rem;
-    min-width: 220px;
-    opacity: 0;
-    pointer-events: none;
-    transform: translateY(-6px);
-    transition: opacity var(--transition-base), transform var(--transition-base);
+  .header__inner {
+    padding: 0.85rem 0;
   }
 
-  .nav-list.is-open {
-    opacity: 1;
-    pointer-events: auto;
-    transform: translateY(0);
+  .site-nav__list li {
+    font-size: 1.1rem;
   }
 
-  .hero {
-    padding-top: 5.2rem;
-  }
-
-  .hero__stats {
-    padding: 1rem;
-  }
-
-  .events__inner {
-    padding: 2.2rem;
-  }
-
-  .site-footer__bottom {
-    flex-direction: column;
-    align-items: flex-start;
+  body.menu-open {
+    overflow: hidden;
   }
 }
 
-@media (max-width: 520px) {
-  h1 {
-    font-size: 2.2rem;
-  }
-
-  .logo {
-    font-size: 1rem;
-  }
-
-  .hero__stats {
+@media (max-width: 640px) {
+  .newsletter__form {
     grid-template-columns: 1fr;
   }
 
-  .hero__actions {
+  .section__header {
     flex-direction: column;
-    align-items: stretch;
+    align-items: flex-start;
   }
 
-  .pillars__tab {
-    flex: 1 1 100%;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
-    scroll-behavior: auto !important;
+  .footer__nav {
+    flex-wrap: wrap;
+    justify-content: center;
   }
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,285 +1,173 @@
 const root = document.documentElement;
+const body = document.body;
 const navToggle = document.querySelector('.nav-toggle');
-const navList = document.querySelector('.nav-list');
+const navList = document.querySelector('.site-nav__list');
 const themeToggle = document.getElementById('theme-toggle');
-const THEME_STORAGE_KEY = 'techphill-theme';
+const yearSpans = document.querySelectorAll('[data-year]');
 
-const prefersDarkScheme = window.matchMedia('(prefers-color-scheme: dark)');
+const THEME_KEY = 'techphilosophers-theme';
 
 const applyTheme = (theme, persist = true) => {
-  root.setAttribute('data-theme', theme);
+  const nextTheme = theme === 'dark' ? 'dark' : 'light';
+  root.setAttribute('data-theme', nextTheme);
   if (themeToggle) {
-    themeToggle.setAttribute(
-      'aria-label',
-      theme === 'dark' ? 'Activate light mode' : 'Activate dark mode'
-    );
+    themeToggle.setAttribute('aria-label', nextTheme === 'dark' ? 'Activate light mode' : 'Activate dark mode');
   }
   if (persist) {
-    localStorage.setItem(THEME_STORAGE_KEY, theme);
+    localStorage.setItem(THEME_KEY, nextTheme);
   }
 };
 
-const getPreferredTheme = () => {
-  const stored = localStorage.getItem(THEME_STORAGE_KEY);
-  if (stored === 'light' || stored === 'dark') {
-    return stored;
-  }
-  return prefersDarkScheme.matches ? 'dark' : 'light';
+const preferredTheme = () => {
+  const stored = localStorage.getItem(THEME_KEY);
+  if (stored === 'light' || stored === 'dark') return stored;
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 };
 
-applyTheme(getPreferredTheme(), false);
+applyTheme(preferredTheme(), false);
 
 if (themeToggle) {
   themeToggle.addEventListener('click', () => {
-    const currentTheme = root.getAttribute('data-theme');
-    const nextTheme = currentTheme === 'dark' ? 'light' : 'dark';
-    applyTheme(nextTheme, true);
+    const current = root.getAttribute('data-theme');
+    applyTheme(current === 'dark' ? 'light' : 'dark');
   });
-
-  const handleSchemeChange = (event) => {
-    if (!localStorage.getItem(THEME_STORAGE_KEY)) {
-      applyTheme(event.matches ? 'dark' : 'light', false);
-    }
-  };
-
-  if (typeof prefersDarkScheme.addEventListener === 'function') {
-    prefersDarkScheme.addEventListener('change', handleSchemeChange);
-  } else if (typeof prefersDarkScheme.addListener === 'function') {
-    prefersDarkScheme.addListener(handleSchemeChange);
-  }
 }
 
 if (navToggle && navList) {
+  const closeNav = () => {
+    navList.classList.remove('is-open');
+    body.classList.remove('menu-open');
+    navToggle.setAttribute('aria-expanded', 'false');
+  };
+
   navToggle.addEventListener('click', () => {
     const isOpen = navList.classList.toggle('is-open');
+    body.classList.toggle('menu-open', isOpen);
     navToggle.setAttribute('aria-expanded', String(isOpen));
   });
 
   navList.querySelectorAll('a').forEach((link) => {
-    link.addEventListener('click', () => {
-      if (navList.classList.contains('is-open')) {
-        navList.classList.remove('is-open');
-        navToggle.setAttribute('aria-expanded', 'false');
-      }
-    });
+    link.addEventListener('click', closeNav);
   });
 
   document.addEventListener('keydown', (event) => {
     if (event.key === 'Escape' && navList.classList.contains('is-open')) {
-      navList.classList.remove('is-open');
-      navToggle.setAttribute('aria-expanded', 'false');
+      closeNav();
       navToggle.focus();
     }
   });
+}
 
-  document.addEventListener('click', (event) => {
-    if (
-      navList.classList.contains('is-open') &&
-      !navList.contains(event.target) &&
-      event.target !== navToggle &&
-      !navToggle.contains(event.target)
-    ) {
-      navList.classList.remove('is-open');
-      navToggle.setAttribute('aria-expanded', 'false');
+yearSpans.forEach((span) => {
+  span.textContent = new Date().getFullYear();
+});
+
+// Newsletter feedback
+const newsletterForm = document.querySelector('.newsletter__form');
+if (newsletterForm) {
+  const feedback = newsletterForm.querySelector('.newsletter__feedback');
+  newsletterForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    if (feedback) {
+      feedback.textContent = 'Thanks for subscribing — wisdom is on its way.';
+    }
+    newsletterForm.reset();
+  });
+}
+
+// Contact form feedback
+const contactForm = document.querySelector('.contact-form');
+if (contactForm) {
+  const feedback = contactForm.querySelector('.form-feedback');
+  contactForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    if (feedback) {
+      feedback.textContent = 'Message received. I will respond with thoughtful clarity soon.';
+    }
+    contactForm.reset();
+  });
+}
+
+// Insights filtering system
+const insightSearchInput = document.getElementById('insight-search');
+const insightItems = Array.from(document.querySelectorAll('.insight-item'));
+const filterButtons = Array.from(document.querySelectorAll('[data-filter]'));
+const resetButton = document.querySelector('[data-reset]');
+const insightCount = document.getElementById('insight-count');
+
+const activeFilters = new Set();
+
+const normalise = (value) => value.toLowerCase();
+
+const updateCount = (visibleItems) => {
+  if (!insightCount) return;
+  const total = insightItems.length;
+  const visible = visibleItems.length;
+  if (visible === total) {
+    insightCount.textContent = 'All entries';
+  } else {
+    insightCount.textContent = `${visible} of ${total}`;
+  }
+};
+
+const applyInsightFilters = () => {
+  const query = insightSearchInput ? normalise(insightSearchInput.value.trim()) : '';
+  const visibleItems = [];
+
+  insightItems.forEach((item) => {
+    const tokens = normalise(item.dataset.tags || '').split(/\s+/).filter(Boolean);
+    const text = normalise(item.textContent || '');
+
+    const matchesSearch = !query || text.includes(query);
+    const matchesFilters = !activeFilters.size || Array.from(activeFilters).every((filter) => tokens.includes(filter));
+
+    const shouldShow = matchesSearch && matchesFilters;
+    item.hidden = !shouldShow;
+    if (shouldShow) {
+      visibleItems.push(item);
     }
   });
-}
 
-const pillarTabs = Array.from(document.querySelectorAll('.pillars__tab'));
-const pillarPanels = Array.from(document.querySelectorAll('.pillars__panel'));
+  updateCount(visibleItems);
+};
 
-if (pillarTabs.length && pillarPanels.length) {
-  const activateTab = (tab) => {
-    const targetId = tab.getAttribute('aria-controls');
-
-    pillarTabs.forEach((button) => {
-      const isActive = button === tab;
-      button.classList.toggle('is-active', isActive);
-      button.setAttribute('aria-selected', String(isActive));
-      button.setAttribute('tabindex', isActive ? '0' : '-1');
-    });
-
-    pillarPanels.forEach((panel) => {
-      const isActive = panel.id === targetId;
-      panel.classList.toggle('is-active', isActive);
-      panel.setAttribute('tabindex', isActive ? '0' : '-1');
-    });
-  };
-
-  pillarTabs.forEach((tab) => {
-    tab.addEventListener('click', () => activateTab(tab));
-    tab.addEventListener('keydown', (event) => {
-      const { key } = event;
-      if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(key)) {
-        return;
-      }
-
-      event.preventDefault();
-      const currentIndex = pillarTabs.indexOf(tab);
-      let nextIndex = currentIndex;
-
-      if (key === 'ArrowRight') {
-        nextIndex = (currentIndex + 1) % pillarTabs.length;
-      } else if (key === 'ArrowLeft') {
-        nextIndex = (currentIndex - 1 + pillarTabs.length) % pillarTabs.length;
-      } else if (key === 'Home') {
-        nextIndex = 0;
-      } else if (key === 'End') {
-        nextIndex = pillarTabs.length - 1;
-      }
-
-      pillarTabs[nextIndex].focus();
-      activateTab(pillarTabs[nextIndex]);
-    });
-
-    // Ensure only the active tab is focusable on load
-    tab.setAttribute('tabindex', tab.classList.contains('is-active') ? '0' : '-1');
-  });
-}
-
-const insightFilters = document.querySelectorAll('.insights__filter');
-const insightCards = document.querySelectorAll('.insight-card');
-
-if (insightFilters.length && insightCards.length) {
-  insightFilters.forEach((button) => {
-    button.setAttribute('aria-pressed', button.classList.contains('is-active') ? 'true' : 'false');
-    button.addEventListener('click', () => {
-      const selectedFilter = button.dataset.filter;
-
-      insightFilters.forEach((control) => {
-        control.classList.toggle('is-active', control === button);
-        control.setAttribute('aria-pressed', String(control === button));
-      });
-
-      insightCards.forEach((card) => {
-        const categories = card.dataset.category.split(' ').filter(Boolean);
-        const shouldShow = selectedFilter === 'all' || categories.includes(selectedFilter);
-        card.hidden = !shouldShow;
-      });
-    });
-  });
-}
-
-const faqItems = document.querySelectorAll('.faq__item');
-
-faqItems.forEach((item, index) => {
-  const button = item.querySelector('button');
-  const body = item.querySelector('.faq__body');
-
-  if (!button || !body) return;
-
-  const bodyId = body.id || `faq-body-${index + 1}`;
-  body.id = bodyId;
-  button.setAttribute('aria-controls', bodyId);
-  body.hidden = true;
-  button.setAttribute('aria-expanded', 'false');
-
+filterButtons.forEach((button) => {
+  button.setAttribute('aria-pressed', 'false');
   button.addEventListener('click', () => {
-    const isOpen = item.classList.toggle('is-open');
-    button.setAttribute('aria-expanded', String(isOpen));
-    body.hidden = !isOpen;
+    const key = normalise(button.dataset.filter || '');
+    if (!key) return;
+    const isActive = activeFilters.has(key);
+    if (isActive) {
+      activeFilters.delete(key);
+    } else {
+      activeFilters.add(key);
+    }
+    button.classList.toggle('is-active', !isActive);
+    button.setAttribute('aria-pressed', String(!isActive));
+    applyInsightFilters();
   });
 });
 
-const newsletterForm = document.querySelector('.newsletter__form');
-
-if (newsletterForm) {
-  const feedbackEl = newsletterForm.querySelector('.newsletter__feedback');
-
-  newsletterForm.addEventListener('submit', (event) => {
-    event.preventDefault();
-    const formData = new FormData(newsletterForm);
-    const email = formData.get('email');
-
-    if (!email) {
-      if (feedbackEl) {
-        feedbackEl.textContent = 'Please add a valid email to subscribe.';
-      }
-      return;
-    }
-
-    if (feedbackEl) {
-      feedbackEl.textContent = 'Thanks for joining our orbit! We will be in touch soon.';
-    }
-
-    newsletterForm.reset();
-    const submitButton = newsletterForm.querySelector('button[type="submit"]');
-    if (submitButton) {
-      submitButton.focus();
-    }
-
-    if (feedbackEl) {
-      setTimeout(() => {
-        feedbackEl.textContent = '';
-      }, 6000);
-    }
+if (insightSearchInput) {
+  insightSearchInput.addEventListener('input', () => {
+    applyInsightFilters();
   });
 }
 
-const statElements = document.querySelectorAll('[data-count]');
-const prefersReducedMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-
-if (statElements.length) {
-  const prefersReducedMotion = prefersReducedMotionQuery.matches;
-
-  statElements.forEach((element) => {
-    const targetValue = parseInt(element.dataset.count, 10);
-    if (Number.isNaN(targetValue)) return;
-
-    if (prefersReducedMotion) {
-      element.textContent = targetValue.toLocaleString('en-US');
-      return;
+if (resetButton) {
+  resetButton.addEventListener('click', () => {
+    activeFilters.clear();
+    filterButtons.forEach((button) => {
+      button.classList.remove('is-active');
+      button.setAttribute('aria-pressed', 'false');
+    });
+    if (insightSearchInput) {
+      insightSearchInput.value = '';
     }
-
-    element.textContent = '0';
+    applyInsightFilters();
   });
-
-  if (!prefersReducedMotion) {
-    const animateCount = (element) => {
-      const targetValue = parseInt(element.dataset.count, 10);
-      if (Number.isNaN(targetValue) || element.dataset.animated === 'true') {
-        return;
-      }
-
-      const duration = 1600;
-      let startTimestamp = null;
-
-      const step = (timestamp) => {
-        if (!startTimestamp) {
-          startTimestamp = timestamp;
-        }
-        const progress = Math.min((timestamp - startTimestamp) / duration, 1);
-        const currentValue = Math.floor(progress * targetValue);
-        element.textContent = currentValue.toLocaleString('en-US');
-
-        if (progress < 1) {
-          window.requestAnimationFrame(step);
-        } else {
-          element.dataset.animated = 'true';
-          element.textContent = targetValue.toLocaleString('en-US');
-        }
-      };
-
-      window.requestAnimationFrame(step);
-    };
-
-    const observer = new IntersectionObserver(
-      (entries, obs) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            animateCount(entry.target);
-            obs.unobserve(entry.target);
-          }
-        });
-      },
-      { threshold: 0.4 }
-    );
-
-    statElements.forEach((element) => observer.observe(element));
-  }
 }
 
-const yearSpan = document.getElementById('copyright-year');
-if (yearSpan) {
-  yearSpan.textContent = new Date().getFullYear();
+if (insightItems.length) {
+  applyInsightFilters();
 }

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Contact — The Tech Philosophers</title>
+    <meta name="description" content="Connect with Raju Thoutu and The Tech Philosophers team." />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Poppins:wght@500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="icon" type="image/svg+xml" href="assets/images/favicon.svg" />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header class="site-header" id="top">
+      <div class="container header__inner">
+        <a class="brand" href="index.html" aria-label="The Tech Philosophers home">
+          <span class="brand__mark" aria-hidden="true">◎</span>
+          <span class="brand__text">
+            <span class="brand__title">The Tech Philosophers</span>
+            <span class="brand__tagline">Raju Thoutu</span>
+          </span>
+        </a>
+        <button class="nav-toggle" type="button" aria-controls="primary-nav" aria-expanded="false">
+          <span class="sr-only">Toggle navigation</span>
+          <span class="nav-toggle__line"></span>
+          <span class="nav-toggle__line"></span>
+          <span class="nav-toggle__line"></span>
+        </button>
+        <nav class="site-nav" aria-label="Primary">
+          <ul id="primary-nav" class="site-nav__list">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="about.html">About</a></li>
+            <li><a href="insights.html">Insights</a></li>
+            <li><a href="projects.html">Projects</a></li>
+            <li><a href="podcasts.html">Podcasts &amp; Videos</a></li>
+            <li><a href="contact.html" aria-current="page">Contact</a></li>
+          </ul>
+        </nav>
+        <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Activate dark mode">
+          <span class="sr-only">Toggle theme</span>
+          <span class="theme-toggle__icon" aria-hidden="true"></span>
+        </button>
+      </div>
+    </header>
+
+    <main id="main-content" class="page">
+      <section class="page-hero">
+        <div class="container narrow">
+          <p class="eyebrow">Contact</p>
+          <h1>Let’s collaborate on meaningful technology, education, and storytelling.</h1>
+          <p class="lead">Send a note about speaking, consulting, partnerships, or community events.</p>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="container contact-grid">
+          <form class="contact-form" action="#" method="post">
+            <div class="form-group">
+              <label for="contact-name">Name</label>
+              <input id="contact-name" name="name" type="text" placeholder="Your full name" required />
+            </div>
+            <div class="form-group">
+              <label for="contact-email">Email</label>
+              <input id="contact-email" name="email" type="email" placeholder="you@example.com" required />
+            </div>
+            <div class="form-group">
+              <label for="contact-message">Message</label>
+              <textarea id="contact-message" name="message" rows="6" placeholder="Tell me how I can help" required></textarea>
+            </div>
+            <button class="btn btn--primary" type="submit">Send message</button>
+            <p class="form-feedback" role="status"></p>
+          </form>
+          <aside class="contact-info">
+            <h2>Stay connected</h2>
+            <p>
+              Prefer direct email? Reach out at <a href="mailto:hello@techphilosophers.com">hello@techphilosophers.com</a>.<br />
+              Follow weekly reflections on LinkedIn, YouTube, and the newsletter.
+            </p>
+            <ul class="contact-links">
+              <li><a href="insights.html">Browse latest insights →</a></li>
+              <li><a href="podcasts.html">Watch the latest podcast →</a></li>
+              <li><a href="projects.html">Review current projects →</a></li>
+            </ul>
+          </aside>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container footer__grid">
+        <div>
+          <a class="brand brand--small" href="index.html">
+            <span class="brand__mark" aria-hidden="true">◎</span>
+            <span class="brand__title">The Tech Philosophers</span>
+          </a>
+          <p class="footer__tagline">Calm intelligence for a meaningful technological future.</p>
+        </div>
+        <nav aria-label="Footer">
+          <ul class="footer__nav">
+            <li><a href="about.html">About</a></li>
+            <li><a href="insights.html">Insights</a></li>
+            <li><a href="projects.html">Projects</a></li>
+            <li><a href="podcasts.html">Podcasts</a></li>
+            <li><a href="contact.html" aria-current="page">Contact</a></li>
+          </ul>
+        </nav>
+      </div>
+      <p class="footer__legal">© <span data-year></span> Raju Thoutu · Crafted with clarity and conscience.</p>
+    </footer>
+
+    <script src="assets/js/main.js" defer></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -2,451 +2,239 @@
 <html lang="en" data-theme="light">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Tech Philosophers &mdash; Exploring the Future of Technology and Ethics</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>The Tech Philosophers — Where Technology Meets Timeless Wisdom</title>
     <meta
       name="description"
-      content="Tech Philosophers is a collective exploring the intersection of technology, humanity, and ethics through conversations, labs, and community events."
+      content="The Tech Philosophers by Raju Thoutu — a premium platform blending AI, technology, mythology, and education research for seekers of clarity."
     />
-    <meta property="og:title" content="Tech Philosophers" />
+    <meta property="og:title" content="The Tech Philosophers" />
     <meta
       property="og:description"
-      content="Exploring the future of technology, ethics, and community through research, storytelling, and immersive gatherings."
+      content="Dashboard hub for AI insights, mythology analogies, education research, and society commentary by Raju Thoutu."
     />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="assets/images/orbit.svg" />
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Tech Philosophers" />
-    <meta
-      name="twitter:description"
-      content="Weekly insights and experiments guiding technology with humanity at the center."
-    />
-    <meta name="theme-color" content="#5b55ff" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&family=Space+Grotesk:wght@400;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Poppins:wght@500;600&display=swap"
       rel="stylesheet"
     />
     <link rel="icon" type="image/svg+xml" href="assets/images/favicon.svg" />
     <link rel="stylesheet" href="assets/css/styles.css" />
   </head>
   <body>
-    <a class="skip-link" href="#home">Skip to main content</a>
     <header class="site-header" id="top">
-      <div class="container header-inner">
-        <a class="logo" href="#home">
-          <span aria-hidden="true">&#9678;</span>
-          Tech Philosophers
+      <div class="container header__inner">
+        <a class="brand" href="index.html" aria-label="The Tech Philosophers home">
+          <span class="brand__mark" aria-hidden="true">◎</span>
+          <span class="brand__text">
+            <span class="brand__title">The Tech Philosophers</span>
+            <span class="brand__tagline">Raju Thoutu</span>
+          </span>
         </a>
-        <nav class="site-nav" aria-label="Primary navigation">
-          <button class="nav-toggle" aria-expanded="false" aria-controls="primary-menu">
-            <span class="sr-only">Toggle navigation</span>
-            <span class="nav-toggle__line"></span>
-            <span class="nav-toggle__line"></span>
-            <span class="nav-toggle__line"></span>
-          </button>
-          <ul id="primary-menu" class="nav-list">
-            <li><a href="#home">Home</a></li>
-            <li><a href="#pillars">Pillars</a></li>
-            <li><a href="#podcast">Podcast</a></li>
-            <li><a href="#insights">Insights</a></li>
-            <li><a href="#events">Events</a></li>
-            <li><a href="#contact">Contact</a></li>
+        <button class="nav-toggle" type="button" aria-controls="primary-nav" aria-expanded="false">
+          <span class="sr-only">Toggle navigation</span>
+          <span class="nav-toggle__line"></span>
+          <span class="nav-toggle__line"></span>
+          <span class="nav-toggle__line"></span>
+        </button>
+        <nav class="site-nav" aria-label="Primary">
+          <ul id="primary-nav" class="site-nav__list">
+            <li><a href="index.html" aria-current="page">Home</a></li>
+            <li><a href="about.html">About</a></li>
+            <li><a href="insights.html">Insights</a></li>
+            <li><a href="projects.html">Projects</a></li>
+            <li><a href="podcasts.html">Podcasts &amp; Videos</a></li>
+            <li><a href="contact.html">Contact</a></li>
           </ul>
         </nav>
-        <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Toggle dark mode">
-          <svg class="theme-toggle__icon" viewBox="0 0 24 24" role="img" aria-hidden="true">
-            <circle class="theme-toggle__sun" cx="12" cy="12" r="5"></circle>
-            <path
-              class="theme-toggle__moon"
-              d="M21 12.79A9 9 0 0 1 11.21 3 7 7 0 1 0 21 12.79z"
-            ></path>
-          </svg>
+        <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Activate dark mode">
+          <span class="sr-only">Toggle theme</span>
+          <span class="theme-toggle__icon" aria-hidden="true"></span>
         </button>
       </div>
     </header>
 
-    <main>
-      <section class="hero" id="home">
-        <div class="container hero__inner">
+    <main id="main-content">
+      <section class="hero">
+        <div class="container hero__grid">
           <div class="hero__content">
-            <p class="eyebrow">Future-forward conversations</p>
-            <h1>Guiding technology with thoughtful philosophy</h1>
-            <p class="hero__lead">
-              We are a collective of technologists, philosophers, and storytellers researching
-              how emerging innovations shape humanity &mdash; and how we can shape them back.
+            <p class="eyebrow">Where Technology Meets Timeless Wisdom</p>
+            <h1>Guidance for thinkers, builders, and parents navigating intelligent futures.</h1>
+            <p class="lead">
+              AI, digital transformation, mythology, education systems, and societal change — simplified in calm, meaningful
+              language by technologist and educator Raju Thoutu.
             </p>
-            <div class="hero__actions">
-              <a class="btn btn--primary" href="#pillars">Explore our pillars</a>
-              <a class="btn btn--ghost" href="#podcast">Listen to the podcast</a>
+            <div class="button-row">
+              <a class="btn btn--primary" href="insights.html">Explore Insights</a>
+              <a class="btn btn--secondary" href="podcasts.html">Watch Podcasts</a>
             </div>
-            <dl class="hero__stats" aria-label="Community statistics">
+            <dl class="hero__metrics" aria-label="Community metrics">
               <div>
-                <dt>Global Members</dt>
-                <dd><span data-count="5800">5,800</span>+</dd>
+                <dt>Insights Published</dt>
+                <dd>320+</dd>
               </div>
               <div>
-                <dt>Research Notes</dt>
-                <dd><span data-count="180">180</span>+</dd>
+                <dt>Podcast &amp; Video Plays</dt>
+                <dd>95K+</dd>
               </div>
               <div>
-                <dt>Episodes Released</dt>
-                <dd><span data-count="74">74</span></dd>
+                <dt>Newsletter Readers</dt>
+                <dd>18K+</dd>
               </div>
             </dl>
           </div>
-          <figure class="hero__visual" aria-hidden="true">
-            <img src="assets/images/orbit.svg" alt="" />
-          </figure>
-        </div>
-      </section>
-
-      <section class="pillars" id="pillars">
-        <div class="container">
-          <div class="section-heading">
-            <p class="eyebrow">Our pillars</p>
-            <h2>Three lenses for asking better questions about technology</h2>
+          <aside class="founder-card" aria-label="About Raju Thoutu">
+            <div class="founder-card__avatar" aria-hidden="true">RT</div>
+            <h2>Raju Thoutu</h2>
+            <p class="founder-card__role">Technologist · Architect · Educator · Storyteller</p>
             <p>
-              The Tech Philosophers framework blends critical analysis, creative experimentation,
-              and grassroots community insight. Choose a pillar to explore how we work.
+              Architecting enterprise systems, researching AI adoption, and translating Bharatiya wisdom into modern, actionable
+              ideas.
             </p>
-          </div>
-          <div class="pillars__layout">
-            <div class="pillars__tabs" role="tablist" aria-label="Pillars">
-              <button class="pillars__tab is-active" role="tab" aria-selected="true" aria-controls="pillar-ethics" id="tab-ethics">
-                Ethics Lab
-              </button>
-              <button class="pillars__tab" role="tab" aria-selected="false" aria-controls="pillar-futures" id="tab-futures">
-                Futures Studio
-              </button>
-              <button class="pillars__tab" role="tab" aria-selected="false" aria-controls="pillar-voices" id="tab-voices">
-                Community Voices
-              </button>
-            </div>
-            <div class="pillars__panels">
-              <article class="pillars__panel is-active" id="pillar-ethics" role="tabpanel" tabindex="0" aria-labelledby="tab-ethics">
-                <h3>Ethics Lab</h3>
-                <p>
-                  We synthesize philosophy, law, and lived experience to prototype ethical guardrails
-                  for emerging technologies. Think practical frameworks, open-source guidelines, and
-                  scenario planning that keeps humans at the center.
-                </p>
-                <ul class="pillars__list">
-                  <li>Publish thought experiments to stress-test new products.</li>
-                  <li>Partner with startups to co-create responsibility playbooks.</li>
-                  <li>Host monthly roundtables with ethicists and policy makers.</li>
-                </ul>
-              </article>
-              <article class="pillars__panel" id="pillar-futures" role="tabpanel" tabindex="-1" aria-labelledby="tab-futures">
-                <h3>Futures Studio</h3>
-                <p>
-                  Our studio turns speculative ideas into tangible prototypes. We run design sprints,
-                  rapid experiments, and open labs to imagine how human values can inform intelligent systems.
-                </p>
-                <ul class="pillars__list">
-                  <li>Create immersive experiences that explore alternative futures.</li>
-                  <li>Publish quarterly field guides on emerging technologies.</li>
-                  <li>Mentor founders building humane tools and civic tech.</li>
-                </ul>
-              </article>
-              <article class="pillars__panel" id="pillar-voices" role="tabpanel" tabindex="-1" aria-labelledby="tab-voices">
-                <h3>Community Voices</h3>
-                <p>
-                  We highlight artists, educators, and activists shaping our tech culture. Through editorial features
-                  and open salons we build inclusive spaces for nuance and honest debate.
-                </p>
-                <ul class="pillars__list">
-                  <li>Curate multimedia stories amplifying global perspectives.</li>
-                  <li>Hold neighborhood listening tours and youth workshops.</li>
-                  <li>Maintain a community knowledge base that anyone can remix.</li>
-                </ul>
-              </article>
-            </div>
-          </div>
+            <a class="founder-card__link" href="about.html">Read the full story →</a>
+          </aside>
         </div>
       </section>
 
-      <section class="podcast" id="podcast">
+      <section class="section section--surface">
         <div class="container">
-          <div class="section-heading section-heading--center">
-            <p class="eyebrow">Listen in</p>
-            <h2>The Tech Philosophers podcast</h2>
-            <p>
-              Weekly dialogues with builders, researchers, and dreamers exploring how we can align technology
-              with the flourishing of people and planet.
-            </p>
+          <div class="section__header">
+            <h2>Navigate the ecosystem</h2>
+            <p>Modular destinations designed like a dashboard for quick exploration.</p>
           </div>
-          <div class="podcast__grid">
-            <article class="podcast__card">
-              <div class="podcast__meta">
-                <span class="podcast__tag">New</span>
-                <span>Episode 74</span>
-              </div>
-              <h3>Designing AI tools that elevate human creativity</h3>
-              <p>
-                Conversation with creative technologist Aisha Bryant about crafting co-creative systems and the
-                rituals that keep teams accountable.
-              </p>
-              <a class="podcast__link" href="#">Play episode</a>
-            </article>
-            <article class="podcast__card">
-              <div class="podcast__meta">
-                <span class="podcast__tag">Deep dive</span>
-                <span>Episode 73</span>
-              </div>
-              <h3>Repairing digital public squares</h3>
-              <p>
-                Civic technologist Nikhil Iyer joins to unpack the infrastructure required for trustworthy information
-                ecosystems and community-first platforms.
-              </p>
-              <a class="podcast__link" href="#">Play episode</a>
-            </article>
-            <article class="podcast__card">
-              <div class="podcast__meta">
-                <span class="podcast__tag">Field note</span>
-                <span>Episode 72</span>
-              </div>
-              <h3>When hardware meets the commons</h3>
-              <p>
-                A dispatch from our field research in Nairobi documenting makerspaces stewarding climate resilient hardware
-                and open knowledge.
-              </p>
-              <a class="podcast__link" href="#">Play episode</a>
-            </article>
+          <div class="quick-nav">
+            <a class="quick-nav__card" href="insights.html#technology-ai">
+              <span class="quick-nav__label">AI &amp; Emerging Tech</span>
+              <span class="quick-nav__meta">Frameworks, enterprise architecture, applied AI toolkits.</span>
+            </a>
+            <a class="quick-nav__card" href="insights.html#mythology-analogies">
+              <span class="quick-nav__label">Mythology &amp; Analogies</span>
+              <span class="quick-nav__meta">Mahabharata, Ramayana, Gita and modern leadership parallels.</span>
+            </a>
+            <a class="quick-nav__card" href="insights.html#education-research">
+              <span class="quick-nav__label">Education &amp; Research</span>
+              <span class="quick-nav__meta">Hybrid learning models, child psychology, school design.</span>
+            </a>
+            <a class="quick-nav__card" href="insights.html#society-deep-thoughts">
+              <span class="quick-nav__label">Society &amp; Deep Thoughts</span>
+              <span class="quick-nav__meta">Culture, work, emotional intelligence, conscious living.</span>
+            </a>
+            <a class="quick-nav__card" href="podcasts.html">
+              <span class="quick-nav__label">Podcasts &amp; Videos</span>
+              <span class="quick-nav__meta">Long-form conversations, YouTube playlists, short reels.</span>
+            </a>
+            <a class="quick-nav__card" href="projects.html">
+              <span class="quick-nav__label">My Projects</span>
+              <span class="quick-nav__meta">AI experiments, Anushtan School concept, enterprise case studies.</span>
+            </a>
           </div>
         </div>
       </section>
 
-      <section class="insights" id="insights">
+      <section class="signature-quote">
         <div class="container">
-          <div class="section-heading">
-            <p class="eyebrow">Latest insights</p>
-            <h2>Research, essays, and tools from the Tech Philosophers team</h2>
-            <p>Filter by theme to see how our thinkers are probing the edges of what technology can become.</p>
-          </div>
-          <div class="insights__filters" role="toolbar" aria-label="Filter insights">
-            <button class="insights__filter is-active" data-filter="all">All</button>
-            <button class="insights__filter" data-filter="ethics">Ethics</button>
-            <button class="insights__filter" data-filter="policy">Policy</button>
-            <button class="insights__filter" data-filter="design">Design</button>
-            <button class="insights__filter" data-filter="community">Community</button>
-          </div>
-          <div class="insights__grid">
-            <article class="insight-card" data-category="ethics policy">
-              <h3>Six questions to ask before shipping autonomous systems</h3>
-              <p>
-                A framework to interrogate alignment, consent, and resilience in AI deployments, drawing on real-world pilots
-                from health care and public transit.
-              </p>
-              <a href="#" class="insight-card__link">Read the field guide</a>
-            </article>
-            <article class="insight-card" data-category="design community">
-              <h3>Listening sessions as a design superpower</h3>
-              <p>
-                Techniques for embedding community listening into product roadmaps, inspired by our workshops in Manila and Mexico City.
-              </p>
-              <a href="#" class="insight-card__link">View the workshop toolkit</a>
-            </article>
-            <article class="insight-card" data-category="policy ethics">
-              <h3>Regenerative governance for digital infrastructure</h3>
-              <p>
-                Exploring how public interest technology can cultivate ecosystems that replenish civic trust and planetary health.
-              </p>
-              <a href="#" class="insight-card__link">Dive into the essay</a>
-            </article>
-            <article class="insight-card" data-category="design ethics">
-              <h3>Reclaiming agency with ritualized tech breaks</h3>
-              <p>
-                Research notes on how purposeful time away from screens recalibrates our relationship with automation and productivity.
-              </p>
-              <a href="#" class="insight-card__link">Read the research notes</a>
-            </article>
-            <article class="insight-card" data-category="community">
-              <h3>The global salons shaping humane innovation</h3>
-              <p>
-                Highlights from our community gatherings celebrating intergenerational wisdom and cross-cultural collaboration.
-              </p>
-              <a href="#" class="insight-card__link">Explore the recap</a>
-            </article>
-            <article class="insight-card" data-category="policy design">
-              <h3>Policy playbooks for algorithmic accountability</h3>
-              <p>
-                Actionable templates for city leaders crafting accountable procurement and auditing practices for AI systems.
-              </p>
-              <a href="#" class="insight-card__link">Download the playbook</a>
-            </article>
-          </div>
+          <blockquote>
+            “Knowledge becomes wisdom only when it transforms your life.”
+            <cite>— The Tech Philosophers</cite>
+          </blockquote>
         </div>
       </section>
 
-      <section class="events" id="events">
+      <section class="section" aria-labelledby="recent-posts">
         <div class="container">
-          <div class="events__inner">
-            <div class="events__content">
-              <p class="eyebrow">Gatherings</p>
-              <h2>Labs, salons, and residencies</h2>
-              <p>
-                Our global community convenes regularly to test ideas and grow collective wisdom. Join an upcoming event
-                or pitch a collaboration.
-              </p>
-              <ul class="events__list">
-                <li>
-                  <strong>June 14</strong> &mdash; "Ethics in the Age of Generative Media" salon, hybrid from Berlin.
-                </li>
-                <li>
-                  <strong>July 02</strong> &mdash; Community residency applications open for systems thinking cohort.
-                </li>
-                <li>
-                  <strong>August 21</strong> &mdash; Futures Studio showcase featuring speculative prototypes.
-                </li>
-              </ul>
-              <a class="btn btn--primary" href="#contact">Request an invite</a>
+          <div class="section__header">
+            <div>
+              <h2 id="recent-posts">Recent insights</h2>
+              <p>Fresh thinking across technology, mythology, education, and society.</p>
             </div>
-            <div class="events__card">
-              <h3>Host with Tech Philosophers</h3>
-              <p>
-                Bring a Tech Philosophers lab to your city, campus, or company. We partner with organizations ready to
-                experiment with community-led innovation.
-              </p>
-              <ul class="events__card-list">
-                <li>Curriculum co-design and facilitation</li>
-                <li>Hybrid event production</li>
-                <li>Documentation and storytelling support</li>
-              </ul>
-              <a class="events__card-link" href="#contact">Start the conversation</a>
-            </div>
+            <a class="section__cta" href="insights.html">View all insights</a>
+          </div>
+          <div class="card-grid">
+            <article class="content-card" data-category="technology-ai" data-tags="llm architecture">
+              <p class="content-card__eyebrow">Technology &amp; AI</p>
+              <h3>Designing enterprise copilots that respect human judgment</h3>
+              <p>Blueprint for blending low-code platforms with trusted guardrails and Bharatiya ethics.</p>
+              <a class="content-card__link" href="article-template.html">Read article</a>
+            </article>
+            <article class="content-card" data-category="mythology-analogies" data-tags="gita leadership">
+              <p class="content-card__eyebrow">Mythology &amp; Analogies</p>
+              <h3>If Rama replaced Arjuna in Kurukshetra</h3>
+              <p>A reflective scenario on duty, restraint, and the science of timely intervention.</p>
+              <a class="content-card__link" href="article-template.html">Read article</a>
+            </article>
+            <article class="content-card" data-category="education-research" data-tags="education psychology">
+              <p class="content-card__eyebrow">Education &amp; Research</p>
+              <h3>Hybrid learning rhythms for holistic schools</h3>
+              <p>Integrating Montessori, CBSE, and Gurukula principles into a future-ready timetable.</p>
+              <a class="content-card__link" href="article-template.html">Read article</a>
+            </article>
+            <article class="content-card" data-category="society-deep-thoughts" data-tags="culture">
+              <p class="content-card__eyebrow">Society &amp; Deep Thoughts</p>
+              <h3>Material success vs. human connection in the AI era</h3>
+              <p>Why purposeful relationships become the competitive advantage for Gen Z leaders.</p>
+              <a class="content-card__link" href="article-template.html">Read article</a>
+            </article>
+            <article class="content-card" data-category="technology-ai" data-tags="pega demo">
+              <p class="content-card__eyebrow">Technology &amp; AI</p>
+              <h3>Pega + Azure AI: Orchestrating value-first automations</h3>
+              <p>A system architecture walkthrough with design notes, APIs, and measurement models.</p>
+              <a class="content-card__link" href="article-template.html">Read article</a>
+            </article>
+            <article class="content-card" data-category="mythology-analogies" data-tags="krishna leadership">
+              <p class="content-card__eyebrow">Mythology &amp; Analogies</p>
+              <h3>Why Krishna intervened before Kamsa’s downfall</h3>
+              <p>Exploring risk sensing, moral calculus, and strategic empathy for modern leaders.</p>
+              <a class="content-card__link" href="article-template.html">Read article</a>
+            </article>
           </div>
         </div>
       </section>
 
-      <section class="newsletter" id="contact">
-        <div class="container newsletter__inner">
-          <div class="newsletter__content">
-            <p class="eyebrow">Stay in orbit</p>
-            <h2>Subscribe and collaborate</h2>
-            <p>
-              Get research highlights, new episode drops, and invitations to private gatherings directly in your inbox.
-              Share a note if you're keen to collaborate.
-            </p>
-            <div class="newsletter__badges" aria-label="Highlights">
-              <span>Monthly digest</span>
-              <span>Early access to tools</span>
-              <span>Community AMAs</span>
-            </div>
+      <section class="section section--surface" aria-labelledby="newsletter">
+        <div class="container newsletter">
+          <div>
+            <h2 id="newsletter">Think Better. Live Better. Build Better.</h2>
+            <p>Weekly email reflections blending practical technology choices with ancient Indian wisdom.</p>
           </div>
-          <form class="newsletter__form" aria-label="Newsletter sign-up">
-            <label class="newsletter__label" for="newsletter-email">Email</label>
-            <input id="newsletter-email" type="email" name="email" placeholder="you@example.com" required />
-            <label class="newsletter__label" for="newsletter-message">Message (optional)</label>
-            <textarea id="newsletter-message" name="message" rows="4" placeholder="Tell us how you want to collaborate"></textarea>
-            <button class="btn btn--primary" type="submit">Join the orbit</button>
-            <p class="newsletter__feedback" role="status" aria-live="polite"></p>
-            <p class="newsletter__smallprint">We respect your time and attention. Unsubscribe anytime.</p>
+          <form class="newsletter__form" action="#" method="post">
+            <label class="sr-only" for="newsletter-email">Email address</label>
+            <input
+              class="newsletter__input"
+              type="email"
+              id="newsletter-email"
+              name="email"
+              placeholder="name@email.com"
+              required
+            />
+            <button class="btn btn--primary" type="submit">Join the newsletter</button>
+            <p class="newsletter__feedback" role="status"></p>
           </form>
-        </div>
-      </section>
-
-      <section class="faq" id="faq">
-        <div class="container">
-          <div class="section-heading section-heading--center">
-            <p class="eyebrow">FAQs</p>
-            <h2>Answers to frequent curiosities</h2>
-            <p>
-              Something still unclear? Browse these highlights or reach out. We love thoughtful questions and dialogue.
-            </p>
-          </div>
-          <div class="faq__list">
-            <article class="faq__item">
-              <h3>
-                <button aria-expanded="false">
-                  How can I contribute to Tech Philosophers research?
-                  <span class="faq__icon" aria-hidden="true"></span>
-                </button>
-              </h3>
-              <div class="faq__body">
-                <p>
-                  We welcome collaborators across disciplines. Share your interests through the form above and our team will
-                  connect you with the right lab or project steward.
-                </p>
-              </div>
-            </article>
-            <article class="faq__item">
-              <h3>
-                <button aria-expanded="false">
-                  Do you offer speaking or facilitation engagements?
-                  <span class="faq__icon" aria-hidden="true"></span>
-                </button>
-              </h3>
-              <div class="faq__body">
-                <p>
-                  Yes! From keynotes on humane innovation to participatory workshops, we tailor experiences for conferences,
-                  universities, and community spaces.
-                </p>
-              </div>
-            </article>
-            <article class="faq__item">
-              <h3>
-                <button aria-expanded="false">
-                  Can I sponsor the podcast or a community residency?
-                  <span class="faq__icon" aria-hidden="true"></span>
-                </button>
-              </h3>
-              <div class="faq__body">
-                <p>
-                  Sponsorships keep our work accessible. Send us a note with your goals and we'll explore ethical partnerships
-                  that align with our values.
-                </p>
-              </div>
-            </article>
-          </div>
         </div>
       </section>
     </main>
 
     <footer class="site-footer">
-      <div class="container site-footer__inner">
-        <div class="site-footer__brand">
-          <a class="logo" href="#top">
-            <span aria-hidden="true">&#9678;</span>
-            Tech Philosophers
+      <div class="container footer__grid">
+        <div>
+          <a class="brand brand--small" href="index.html">
+            <span class="brand__mark" aria-hidden="true">◎</span>
+            <span class="brand__title">The Tech Philosophers</span>
           </a>
-          <p>
-            Charting technology's impact with curiosity, compassion, and courage. Join us as we build futures where everyone can thrive.
-          </p>
+          <p class="footer__tagline">Calm intelligence for a meaningful technological future.</p>
         </div>
-        <div class="site-footer__links">
-          <div>
-            <h3>Explore</h3>
-            <ul>
-              <li><a href="#pillars">Pillars</a></li>
-              <li><a href="#podcast">Podcast</a></li>
-              <li><a href="#insights">Insights</a></li>
-            </ul>
-          </div>
-          <div>
-            <h3>Connect</h3>
-            <ul>
-              <li><a href="mailto:hello@techphilosophers.com">Email</a></li>
-              <li><a href="#events">Events</a></li>
-              <li><a href="#faq">FAQs</a></li>
-            </ul>
-          </div>
-          <div>
-            <h3>Social</h3>
-            <ul>
-              <li><a href="#">Mastodon</a></li>
-              <li><a href="#">YouTube</a></li>
-              <li><a href="#">Substack</a></li>
-            </ul>
-          </div>
-        </div>
+        <nav aria-label="Footer">
+          <ul class="footer__nav">
+            <li><a href="about.html">About</a></li>
+            <li><a href="insights.html">Insights</a></li>
+            <li><a href="projects.html">Projects</a></li>
+            <li><a href="podcasts.html">Podcasts</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </nav>
       </div>
-      <div class="site-footer__bottom">
-        <p>&copy; <span id="copyright-year"></span> Tech Philosophers. Crafted with care.</p>
-        <a href="#top" class="site-footer__top">Back to top</a>
-      </div>
+      <p class="footer__legal">© <span data-year></span> Raju Thoutu · Crafted with clarity and conscience.</p>
     </footer>
 
     <script src="assets/js/main.js" defer></script>

--- a/insights.html
+++ b/insights.html
@@ -1,0 +1,313 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Insights — The Tech Philosophers</title>
+    <meta
+      name="description"
+      content="Explore modular insights across technology, mythology, education research, and society with expandable navigation and tags."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Poppins:wght@500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="icon" type="image/svg+xml" href="assets/images/favicon.svg" />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header class="site-header" id="top">
+      <div class="container header__inner">
+        <a class="brand" href="index.html" aria-label="The Tech Philosophers home">
+          <span class="brand__mark" aria-hidden="true">◎</span>
+          <span class="brand__text">
+            <span class="brand__title">The Tech Philosophers</span>
+            <span class="brand__tagline">Raju Thoutu</span>
+          </span>
+        </a>
+        <button class="nav-toggle" type="button" aria-controls="primary-nav" aria-expanded="false">
+          <span class="sr-only">Toggle navigation</span>
+          <span class="nav-toggle__line"></span>
+          <span class="nav-toggle__line"></span>
+          <span class="nav-toggle__line"></span>
+        </button>
+        <nav class="site-nav" aria-label="Primary">
+          <ul id="primary-nav" class="site-nav__list">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="about.html">About</a></li>
+            <li><a href="insights.html" aria-current="page">Insights</a></li>
+            <li><a href="projects.html">Projects</a></li>
+            <li><a href="podcasts.html">Podcasts &amp; Videos</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </nav>
+        <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Activate dark mode">
+          <span class="sr-only">Toggle theme</span>
+          <span class="theme-toggle__icon" aria-hidden="true"></span>
+        </button>
+      </div>
+    </header>
+
+    <main id="main-content" class="page insights">
+      <section class="page-hero">
+        <div class="container">
+          <p class="eyebrow">Insights Library</p>
+          <h1>A modular, extendable knowledge system built for clarity.</h1>
+          <p class="lead">
+            Browse 500+ articles by category, subcategory, year, or tag. The navigation on the left scrolls independently so you
+            can explore without losing context.
+          </p>
+        </div>
+      </section>
+
+      <div class="container insights__layout">
+        <aside class="insights__sidebar" aria-label="Insights navigation">
+          <form class="search" role="search">
+            <label class="search__label" for="insight-search">Search the library</label>
+            <input
+              id="insight-search"
+              type="search"
+              name="search"
+              placeholder="Search topics, tags, or titles..."
+              autocomplete="off"
+            />
+          </form>
+
+          <nav class="side-nav" aria-label="Categories">
+            <details class="side-nav__section" id="technology-ai" open>
+              <summary>Technology &amp; AI Insights</summary>
+              <div class="side-nav__content">
+                <p class="side-nav__hint">Subcategories</p>
+                <ul>
+                  <li><button type="button" data-filter="llms-slms">LLMs &amp; SLMs</button></li>
+                  <li><button type="button" data-filter="enterprise-architecture">Enterprise Architecture</button></li>
+                  <li><button type="button" data-filter="pega-insights">Pega Insights</button></li>
+                  <li><button type="button" data-filter="applied-ai">Applied AI</button></li>
+                  <li><button type="button" data-filter="experiments-demos">Experiments &amp; Demos</button></li>
+                </ul>
+                <p class="side-nav__hint">Archives</p>
+                <ul class="side-nav__archive">
+                  <li><button type="button" data-filter="year-2024">2024</button></li>
+                  <li><button type="button" data-filter="year-2025">2025</button></li>
+                  <li><button type="button" data-filter="year-2026">2026</button></li>
+                </ul>
+              </div>
+            </details>
+            <details class="side-nav__section" id="mythology-analogies" open>
+              <summary>Mythology &amp; My Analogies</summary>
+              <div class="side-nav__content">
+                <p class="side-nav__hint">Subcategories</p>
+                <ul>
+                  <li><button type="button" data-filter="mahabharata">Mahabharata</button></li>
+                  <li><button type="button" data-filter="ramayana">Ramayana</button></li>
+                  <li><button type="button" data-filter="gita">Gita</button></li>
+                  <li><button type="button" data-filter="modern-analogies">Modern Analogies</button></li>
+                  <li><button type="button" data-filter="leadership-lessons">Leadership Lessons</button></li>
+                </ul>
+                <p class="side-nav__hint">Example posts</p>
+                <ul>
+                  <li><a href="article-template.html">If Rama replaced Arjuna</a></li>
+                  <li><a href="article-template.html">Why Krishna intervened with Kamsa</a></li>
+                </ul>
+              </div>
+            </details>
+            <details class="side-nav__section" id="education-research" open>
+              <summary>Education &amp; Research</summary>
+              <div class="side-nav__content">
+                <p class="side-nav__hint">Subcategories</p>
+                <ul>
+                  <li><button type="button" data-filter="us-education">US Education System</button></li>
+                  <li><button type="button" data-filter="montessori-cbse-gurukula">Montessori vs CBSE vs Gurukula</button></li>
+                  <li><button type="button" data-filter="child-psychology">Child Psychology</button></li>
+                  <li><button type="button" data-filter="anushtan-school">Anushtan School Ideation</button></li>
+                  <li><button type="button" data-filter="pedagogy-research">Pedagogy Research</button></li>
+                </ul>
+                <p class="side-nav__hint">Archives</p>
+                <ul class="side-nav__archive">
+                  <li><button type="button" data-filter="education-2024">Education Research 2024</button></li>
+                  <li><button type="button" data-filter="education-2025">Education Research 2025</button></li>
+                  <li><button type="button" data-filter="education-2026">Education Research 2026</button></li>
+                </ul>
+              </div>
+            </details>
+            <details class="side-nav__section" id="society-deep-thoughts" open>
+              <summary>Society, Life &amp; Deep Thoughts</summary>
+              <div class="side-nav__content">
+                <p class="side-nav__hint">Subcategories</p>
+                <ul>
+                  <li><button type="button" data-filter="emotional-behavior">Emotional Behavior</button></li>
+                  <li><button type="button" data-filter="relationships">Relationships</button></li>
+                  <li><button type="button" data-filter="cultural-shifts">Cultural Shifts</button></li>
+                  <li><button type="button" data-filter="gen-z-analysis">Gen Z Analysis</button></li>
+                  <li><button type="button" data-filter="modern-work">Modern Work &amp; Lifestyle</button></li>
+                </ul>
+                <p class="side-nav__hint">Example topics</p>
+                <ul>
+                  <li><a href="article-template.html">Material success vs human connection</a></li>
+                  <li><a href="article-template.html">Why Gen Z prioritizes growth over love</a></li>
+                </ul>
+              </div>
+            </details>
+          </nav>
+
+          <div class="tag-cloud" aria-label="Popular tags">
+            <p class="tag-cloud__title">Popular tags</p>
+            <div class="tag-cloud__chips">
+              <button type="button" data-filter="krishna">Krishna</button>
+              <button type="button" data-filter="llm">LLM</button>
+              <button type="button" data-filter="education">Education</button>
+              <button type="button" data-filter="architecture">Architecture</button>
+              <button type="button" data-filter="culture">Culture</button>
+              <button type="button" data-filter="child-psychology">Child Psychology</button>
+            </div>
+          </div>
+        </aside>
+
+        <section class="insights__content" aria-live="polite">
+          <div class="insights__controls">
+            <p><strong>Showing</strong> <span id="insight-count">All entries</span></p>
+            <button class="btn btn--ghost" type="button" data-reset>Reset filters</button>
+          </div>
+          <div class="insight-list">
+            <article class="insight-item" data-tags="llm llms-slms enterprise-architecture year-2025" data-category="Technology &amp; AI">
+              <header>
+                <p class="insight-item__meta">Technology &amp; AI · 2025</p>
+                <h2><a href="article-template.html">Calibrating small language models for regulated enterprises</a></h2>
+              </header>
+              <p>
+                A governance-first approach to building reliable, efficient SLM stacks that blend Azure Foundry with tradition-based
+                design principles.
+              </p>
+              <ul class="insight-item__tags">
+                <li>#LLM</li>
+                <li>#EnterpriseArchitecture</li>
+                <li>#ResponsibleAI</li>
+              </ul>
+            </article>
+
+            <article class="insight-item" data-tags="pega-insights applied-ai enterprise-architecture year-2024" data-category="Technology &amp; AI">
+              <header>
+                <p class="insight-item__meta">Technology &amp; AI · 2024</p>
+                <h2><a href="article-template.html">Pega + AI playbooks for humane automations</a></h2>
+              </header>
+              <p>Design guardrails, human handoffs, and measurement dashboards for AI-assisted customer journeys.</p>
+              <ul class="insight-item__tags">
+                <li>#Pega</li>
+                <li>#AppliedAI</li>
+                <li>#ExperienceDesign</li>
+              </ul>
+            </article>
+
+            <article class="insight-item" data-tags="mahabharata leadership-lessons krishna modern-analogies" data-category="Mythology &amp; Analogies">
+              <header>
+                <p class="insight-item__meta">Mythology &amp; Analogies</p>
+                <h2><a href="article-template.html">If Rama replaced Arjuna in Kurukshetra</a></h2>
+              </header>
+              <p>Decoding discipline, humility, and situational leadership through a cross-epic thought experiment.</p>
+              <ul class="insight-item__tags">
+                <li>#Mahabharata</li>
+                <li>#Leadership</li>
+                <li>#StrategicWisdom</li>
+              </ul>
+            </article>
+
+            <article class="insight-item" data-tags="education education-2024 us-education year-2024" data-category="Education &amp; Research">
+              <header>
+                <p class="insight-item__meta">Education &amp; Research · 2024</p>
+                <h2><a href="article-template.html">US education systems decoded for Indian parents</a></h2>
+              </header>
+              <p>A parent-friendly guide comparing terminology, expectations, and holistic growth from Pre-K to Grade 12.</p>
+              <ul class="insight-item__tags">
+                <li>#Education</li>
+                <li>#Parenting</li>
+                <li>#HybridLearning</li>
+              </ul>
+            </article>
+
+            <article class="insight-item" data-tags="gen-z-analysis culture modern-work year-2024" data-category="Society &amp; Deep Thoughts">
+              <header>
+                <p class="insight-item__meta">Society &amp; Deep Thoughts</p>
+                <h2><a href="article-template.html">Why Gen Z prioritizes growth over love</a></h2>
+              </header>
+              <p>
+                Investigating ambition, belonging, and human connection in the context of modern work, social media, and AI.
+              </p>
+              <ul class="insight-item__tags">
+                <li>#Culture</li>
+                <li>#GenZ</li>
+                <li>#HumanPotential</li>
+              </ul>
+            </article>
+
+            <article class="insight-item" data-tags="anushtan-school pedagogy-research education-2025 year-2025" data-category="Education &amp; Research">
+              <header>
+                <p class="insight-item__meta">Education &amp; Research · 2025</p>
+                <h2><a href="article-template.html">Anushtan holistic school — model, research, vision</a></h2>
+              </header>
+              <p>
+                Bringing together Gurukula-inspired routines, modern pedagogy, and AI learning assistants for conscious schooling.
+              </p>
+              <ul class="insight-item__tags">
+                <li>#Anushtan</li>
+                <li>#HolisticSchooling</li>
+                <li>#AIinEducation</li>
+              </ul>
+            </article>
+
+            <article class="insight-item" data-tags="relationships emotional-behavior culture year-2024" data-category="Society &amp; Deep Thoughts">
+              <header>
+                <p class="insight-item__meta">Society &amp; Deep Thoughts</p>
+                <h2><a href="article-template.html">Material success vs human connection</a></h2>
+              </header>
+              <p>A reflective essay on redefining success metrics in families, teams, and communities.</p>
+              <ul class="insight-item__tags">
+                <li>#Relationships</li>
+                <li>#EmotionalIntelligence</li>
+                <li>#Purpose</li>
+              </ul>
+            </article>
+
+            <article class="insight-item" data-tags="experiments-demos llm architecture year-2026" data-category="Technology &amp; AI">
+              <header>
+                <p class="insight-item__meta">Technology &amp; AI · 2026</p>
+                <h2><a href="article-template.html">Sandbox: Cultural memory graph copilots</a></h2>
+              </header>
+              <p>Prototype for blending Sri Yantra-inspired visualizations with AI-driven knowledge recall systems.</p>
+              <ul class="insight-item__tags">
+                <li>#Experiments</li>
+                <li>#Architecture</li>
+                <li>#FuturesThinking</li>
+              </ul>
+            </article>
+          </div>
+        </section>
+      </div>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container footer__grid">
+        <div>
+          <a class="brand brand--small" href="index.html">
+            <span class="brand__mark" aria-hidden="true">◎</span>
+            <span class="brand__title">The Tech Philosophers</span>
+          </a>
+          <p class="footer__tagline">Calm intelligence for a meaningful technological future.</p>
+        </div>
+        <nav aria-label="Footer">
+          <ul class="footer__nav">
+            <li><a href="about.html">About</a></li>
+            <li><a href="insights.html" aria-current="page">Insights</a></li>
+            <li><a href="projects.html">Projects</a></li>
+            <li><a href="podcasts.html">Podcasts</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </nav>
+      </div>
+      <p class="footer__legal">© <span data-year></span> Raju Thoutu · Crafted with clarity and conscience.</p>
+    </footer>
+
+    <script src="assets/js/main.js" defer></script>
+  </body>
+</html>

--- a/podcasts.html
+++ b/podcasts.html
@@ -1,0 +1,296 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Podcasts &amp; Videos — The Tech Philosophers</title>
+    <meta
+      name="description"
+      content="Watch and listen to Raju Thoutu’s podcasts, videos, and curated YouTube playlists across technology, mythology, society, and education."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Poppins:wght@500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="icon" type="image/svg+xml" href="assets/images/favicon.svg" />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header class="site-header" id="top">
+      <div class="container header__inner">
+        <a class="brand" href="index.html" aria-label="The Tech Philosophers home">
+          <span class="brand__mark" aria-hidden="true">◎</span>
+          <span class="brand__text">
+            <span class="brand__title">The Tech Philosophers</span>
+            <span class="brand__tagline">Raju Thoutu</span>
+          </span>
+        </a>
+        <button class="nav-toggle" type="button" aria-controls="primary-nav" aria-expanded="false">
+          <span class="sr-only">Toggle navigation</span>
+          <span class="nav-toggle__line"></span>
+          <span class="nav-toggle__line"></span>
+          <span class="nav-toggle__line"></span>
+        </button>
+        <nav class="site-nav" aria-label="Primary">
+          <ul id="primary-nav" class="site-nav__list">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="about.html">About</a></li>
+            <li><a href="insights.html">Insights</a></li>
+            <li><a href="projects.html">Projects</a></li>
+            <li><a href="podcasts.html" aria-current="page">Podcasts &amp; Videos</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </nav>
+        <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Activate dark mode">
+          <span class="sr-only">Toggle theme</span>
+          <span class="theme-toggle__icon" aria-hidden="true"></span>
+        </button>
+      </div>
+    </header>
+
+    <main id="main-content" class="page">
+      <section class="page-hero">
+        <div class="container">
+          <p class="eyebrow">Podcasts &amp; Videos</p>
+          <h1>Listen, watch, and learn — without leaving the Tech Philosophers experience.</h1>
+          <p class="lead">
+            Responsive embeds keep every video and playlist inside the site. Infinite scroll or pagination can be activated as the
+            library grows beyond 100 episodes.
+          </p>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="container video-hub">
+          <article class="video-feature">
+            <header>
+              <p class="video-feature__category">Featured Conversation</p>
+              <h2>Designing AI with timeless wisdom</h2>
+            </header>
+            <div class="video-frame">
+              <iframe
+                src="https://www.youtube.com/embed/DyDfgMOUjCI"
+                title="Designing AI with timeless wisdom"
+                loading="lazy"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                allowfullscreen
+              ></iframe>
+            </div>
+            <p>
+              Raju shares frameworks for balancing automation with ethics, drawing from Vedic literature, enterprise case studies,
+              and education research.
+            </p>
+          </article>
+
+          <section aria-labelledby="tech-playlist" class="playlist">
+            <header>
+              <h2 id="tech-playlist">Tech playlist</h2>
+              <p>Deep dives into LLMs, architecture, and digital transformation.</p>
+            </header>
+            <div class="playlist__grid">
+              <article class="playlist__item">
+                <div class="video-frame">
+                  <iframe
+                    src="https://www.youtube.com/embed/videoseries?list=PL8dPuuaLjXtMczXZUmjbNkiX0A6Jd4cVX"
+                    title="Tech playlist"
+                    loading="lazy"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen
+                  ></iframe>
+                </div>
+                <h3>Enterprise AI copilots</h3>
+                <p>Case studies, architectural decisions, and guardrail playbooks.</p>
+              </article>
+              <article class="playlist__item">
+                <div class="video-frame">
+                  <iframe
+                    src="https://www.youtube.com/embed/FnJIb4A-DcU"
+                    title="Applied AI walkthrough"
+                    loading="lazy"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen
+                  ></iframe>
+                </div>
+                <h3>Applied AI walkthrough</h3>
+                <p>Live demo of connecting Azure Foundry, Pega workflows, and analytics dashboards.</p>
+              </article>
+            </div>
+          </section>
+
+          <section aria-labelledby="mythology-playlist" class="playlist">
+            <header>
+              <h2 id="mythology-playlist">Mythology playlist</h2>
+              <p>Dialogues translating epics into modern metaphors for leadership and parenting.</p>
+            </header>
+            <div class="playlist__grid">
+              <article class="playlist__item">
+                <div class="video-frame">
+                  <iframe
+                    src="https://www.youtube.com/embed/_b2KXgB5m4c"
+                    title="Mythology reflections"
+                    loading="lazy"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen
+                  ></iframe>
+                </div>
+                <h3>Mahabharata reflections</h3>
+                <p>Arjuna, Krishna, and the art of strategic empathy.</p>
+              </article>
+              <article class="playlist__item">
+                <div class="video-frame">
+                  <iframe
+                    src="https://www.youtube.com/embed/VF29Zy4Zz1o"
+                    title="Ramayana analogies"
+                    loading="lazy"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen
+                  ></iframe>
+                </div>
+                <h3>Ramayana analogies</h3>
+                <p>Exploring dharma, boundaries, and compassionate leadership.</p>
+              </article>
+            </div>
+          </section>
+
+          <section aria-labelledby="society-playlist" class="playlist">
+            <header>
+              <h2 id="society-playlist">Society playlist</h2>
+              <p>Culture, work, and emotional wellbeing in an AI-driven world.</p>
+            </header>
+            <div class="playlist__grid">
+              <article class="playlist__item">
+                <div class="video-frame">
+                  <iframe
+                    src="https://www.youtube.com/embed/videoseries?list=PL55713C70BA91BD6E"
+                    title="Society playlist"
+                    loading="lazy"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen
+                  ></iframe>
+                </div>
+                <h3>Meaningful work</h3>
+                <p>Conversations on work-life harmony and conscious productivity.</p>
+              </article>
+              <article class="playlist__item">
+                <div class="video-frame">
+                  <iframe
+                    src="https://www.youtube.com/embed/1qN72LEQnaU"
+                    title="Emotional intelligence"
+                    loading="lazy"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen
+                  ></iframe>
+                </div>
+                <h3>Emotional intelligence labs</h3>
+                <p>Practical exercises for families, teams, and young adults.</p>
+              </article>
+            </div>
+          </section>
+
+          <section aria-labelledby="education-playlist" class="playlist">
+            <header>
+              <h2 id="education-playlist">Education playlist</h2>
+              <p>Hybrid learning models, pedagogy research, and child psychology conversations.</p>
+            </header>
+            <div class="playlist__grid">
+              <article class="playlist__item">
+                <div class="video-frame">
+                  <iframe
+                    src="https://www.youtube.com/embed/videoseries?list=PL8dPuuaLjXtOeEc9ME62zTfqc0hY0Dq2o"
+                    title="Education playlist"
+                    loading="lazy"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen
+                  ></iframe>
+                </div>
+                <h3>Hybrid classrooms</h3>
+                <p>Designing rhythms that merge Montessori, CBSE, and Gurukula practices.</p>
+              </article>
+              <article class="playlist__item">
+                <div class="video-frame">
+                  <iframe
+                    src="https://www.youtube.com/embed/6Af6b_wyiwI"
+                    title="Child psychology essentials"
+                    loading="lazy"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen
+                  ></iframe>
+                </div>
+                <h3>Child psychology essentials</h3>
+                <p>Understanding emotions, attention, and motivation in digital-first students.</p>
+              </article>
+            </div>
+          </section>
+
+          <section aria-labelledby="shorts-playlist" class="playlist">
+            <header>
+              <h2 id="shorts-playlist">Shorts &amp; reels</h2>
+              <p>60-second insights, bilingual reflections, and event highlights.</p>
+            </header>
+            <div class="playlist__grid">
+              <article class="playlist__item">
+                <div class="video-frame">
+                  <iframe
+                    src="https://www.youtube.com/embed/_OBlgSz8sSM"
+                    title="Short insight"
+                    loading="lazy"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen
+                  ></iframe>
+                </div>
+                <h3>Rapid tech wisdom</h3>
+                <p>Quick reminders for navigating AI adoption with calm confidence.</p>
+              </article>
+              <article class="playlist__item">
+                <div class="video-frame">
+                  <iframe
+                    src="https://www.youtube.com/embed/5qap5aO4i9A"
+                    title="Ambient focus stream"
+                    loading="lazy"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen
+                  ></iframe>
+                </div>
+                <h3>Focus and reflection</h3>
+                <p>Soundscapes for mindful work sessions and journaling.</p>
+              </article>
+            </div>
+          </section>
+
+          <div class="pagination-hint">
+            <button class="btn btn--secondary" type="button">Load more episodes</button>
+            <p class="pagination-hint__note">
+              Activate automatic pagination or infinite scroll via JavaScript once the library exceeds the initial playlists.
+            </p>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container footer__grid">
+        <div>
+          <a class="brand brand--small" href="index.html">
+            <span class="brand__mark" aria-hidden="true">◎</span>
+            <span class="brand__title">The Tech Philosophers</span>
+          </a>
+          <p class="footer__tagline">Calm intelligence for a meaningful technological future.</p>
+        </div>
+        <nav aria-label="Footer">
+          <ul class="footer__nav">
+            <li><a href="about.html">About</a></li>
+            <li><a href="insights.html">Insights</a></li>
+            <li><a href="projects.html">Projects</a></li>
+            <li><a href="podcasts.html" aria-current="page">Podcasts</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </nav>
+      </div>
+      <p class="footer__legal">© <span data-year></span> Raju Thoutu · Crafted with clarity and conscience.</p>
+    </footer>
+
+    <script src="assets/js/main.js" defer></script>
+  </body>
+</html>

--- a/projects.html
+++ b/projects.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Projects — The Tech Philosophers</title>
+    <meta
+      name="description"
+      content="Explore the core projects led by Raju Thoutu across education, AI experiments, enterprise work, and multimedia."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Poppins:wght@500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="icon" type="image/svg+xml" href="assets/images/favicon.svg" />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header class="site-header" id="top">
+      <div class="container header__inner">
+        <a class="brand" href="index.html" aria-label="The Tech Philosophers home">
+          <span class="brand__mark" aria-hidden="true">◎</span>
+          <span class="brand__text">
+            <span class="brand__title">The Tech Philosophers</span>
+            <span class="brand__tagline">Raju Thoutu</span>
+          </span>
+        </a>
+        <button class="nav-toggle" type="button" aria-controls="primary-nav" aria-expanded="false">
+          <span class="sr-only">Toggle navigation</span>
+          <span class="nav-toggle__line"></span>
+          <span class="nav-toggle__line"></span>
+          <span class="nav-toggle__line"></span>
+        </button>
+        <nav class="site-nav" aria-label="Primary">
+          <ul id="primary-nav" class="site-nav__list">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="about.html">About</a></li>
+            <li><a href="insights.html">Insights</a></li>
+            <li><a href="projects.html" aria-current="page">Projects</a></li>
+            <li><a href="podcasts.html">Podcasts &amp; Videos</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </nav>
+        <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Activate dark mode">
+          <span class="sr-only">Toggle theme</span>
+          <span class="theme-toggle__icon" aria-hidden="true"></span>
+        </button>
+      </div>
+    </header>
+
+    <main id="main-content" class="page">
+      <section class="page-hero">
+        <div class="container">
+          <p class="eyebrow">Projects</p>
+          <h1>Living laboratories where technology, education, and storytelling meet.</h1>
+          <p class="lead">Each project is a module in the Tech Philosophers ecosystem — built to scale, share, and evolve.</p>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="container project-grid">
+          <article class="project-card">
+            <header>
+              <p class="project-card__category">Education Research</p>
+              <h2>Anushtan Holistic School</h2>
+            </header>
+            <p class="project-card__summary">Philosophy · Model · Research · Vision</p>
+            <ul>
+              <li>Curriculum architecture balancing STEM, arts, and dharmic wisdom.</li>
+              <li>AI-assisted personalized guidance with human mentors.</li>
+              <li>Campus planning integrating sacred geometry and modern ergonomics.</li>
+              <li>Community labs for parents and educators to co-create rituals.</li>
+            </ul>
+            <a class="project-card__link" href="article-template.html">View research blueprint →</a>
+          </article>
+
+          <article class="project-card">
+            <header>
+              <p class="project-card__category">AI Experiments</p>
+              <h2>Applied AI &amp; Experience Demos</h2>
+            </header>
+            <p class="project-card__summary">Azure Foundry · Pega + AI · Postman demos</p>
+            <ul>
+              <li>Composable AI copilots for customer service, learning, and design.</li>
+              <li>Knowledge graph visualizations using Sri Yantra-inspired layouts.</li>
+              <li>Scenario libraries for responsible AI decisions.</li>
+              <li>Hands-on walkthroughs with GitHub repos and API collections.</li>
+            </ul>
+            <a class="project-card__link" href="article-template.html">Explore experiments →</a>
+          </article>
+
+          <article class="project-card">
+            <header>
+              <p class="project-card__category">Enterprise Work</p>
+              <h2>Architecture &amp; Transformation</h2>
+            </header>
+            <p class="project-card__summary">Citi · ConEd · MasterCard · CRMS · Upgrades</p>
+            <ul>
+              <li>Designing platforms that respect regulations, scale, and user empathy.</li>
+              <li>Migration accelerators for legacy to cloud transformations.</li>
+              <li>Playbooks aligning business, architecture, and Bharatiya principles.</li>
+              <li>Coaching leaders on AI literacy and human-centric metrics.</li>
+            </ul>
+            <a class="project-card__link" href="article-template.html">See enterprise case notes →</a>
+          </article>
+
+          <article class="project-card">
+            <header>
+              <p class="project-card__category">Media &amp; Community</p>
+              <h2>Podcasts &amp; Web Content</h2>
+            </header>
+            <p class="project-card__summary">Telugu + English</p>
+            <ul>
+              <li>Long-form episodes blending mythological narratives with modern dilemmas.</li>
+              <li>Video explainers with calm motion graphics and neural-inspired visuals.</li>
+              <li>Short reels highlighting parenting, AI ethics, and emotional intelligence.</li>
+              <li>Community Q&amp;A sessions, workshops, and live stream archives.</li>
+            </ul>
+            <a class="project-card__link" href="podcasts.html">Visit the podcasts hub →</a>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container footer__grid">
+        <div>
+          <a class="brand brand--small" href="index.html">
+            <span class="brand__mark" aria-hidden="true">◎</span>
+            <span class="brand__title">The Tech Philosophers</span>
+          </a>
+          <p class="footer__tagline">Calm intelligence for a meaningful technological future.</p>
+        </div>
+        <nav aria-label="Footer">
+          <ul class="footer__nav">
+            <li><a href="about.html">About</a></li>
+            <li><a href="insights.html">Insights</a></li>
+            <li><a href="projects.html" aria-current="page">Projects</a></li>
+            <li><a href="podcasts.html">Podcasts</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </nav>
+      </div>
+      <p class="footer__legal">© <span data-year></span> Raju Thoutu · Crafted with clarity and conscience.</p>
+    </footer>
+
+    <script src="assets/js/main.js" defer></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- rebuild the Tech Philosophers website as a multi-page, premium personal brand experience with a dashboard-style homepage
- add dedicated About, Insights, Projects, Podcasts & Videos, Contact, and article template pages with modular navigation and structured content placeholders
- refresh global styling and scripts to deliver futuristic theming, responsive navigation, newsletter/contact feedback, and extensible filtering for the insights library

## Testing
- No automated tests (static site)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917e6beafbc832dbb2364be01a992a3)